### PR TITLE
Feat/chat

### DIFF
--- a/src/main/java/com/kindtalk/server/ServerApplication.java
+++ b/src/main/java/com/kindtalk/server/ServerApplication.java
@@ -2,12 +2,14 @@ package com.kindtalk.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ServerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ServerApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(ServerApplication.class, args);
+  }
 
 }

--- a/src/main/java/com/kindtalk/server/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/kindtalk/server/chatroom/controller/ChatRoomController.java
@@ -1,0 +1,43 @@
+package com.kindtalk.server.chatroom.controller;
+
+import com.kindtalk.server.chatroom.dto.ChatRoomCreateRequest;
+import com.kindtalk.server.chatroom.dto.ChatRoomResponse;
+import com.kindtalk.server.chatroom.dto.UpdateAnnounceRequest;
+import com.kindtalk.server.chatroom.service.ChatRoomService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/chatroom")
+@RequiredArgsConstructor
+public class ChatRoomController {
+
+  private final ChatRoomService chatRoomService;
+
+  @PostMapping
+  public ResponseEntity<ChatRoomResponse> create(
+    @Valid @RequestBody ChatRoomCreateRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+      .body(chatRoomService.create(request));
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<ChatRoomResponse> findById(@PathVariable Long id) {
+    return ResponseEntity.ok(chatRoomService.findById(id));
+  }
+
+  @PatchMapping
+  public ResponseEntity<ChatRoomResponse> update(
+    @RequestBody UpdateAnnounceRequest request) {
+    return ResponseEntity.ok(chatRoomService.updateAnnounce(request));
+  }
+}

--- a/src/main/java/com/kindtalk/server/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/kindtalk/server/chatroom/controller/ChatRoomController.java
@@ -35,9 +35,10 @@ public class ChatRoomController {
     return ResponseEntity.ok(chatRoomService.findById(id));
   }
 
-  @PatchMapping
+  @PatchMapping("/{id}")
   public ResponseEntity<ChatRoomResponse> update(
+    @PathVariable Long id,
     @RequestBody UpdateAnnounceRequest request) {
-    return ResponseEntity.ok(chatRoomService.updateAnnounce(request));
+    return ResponseEntity.ok(chatRoomService.updateAnnounce(id, request));
   }
 }

--- a/src/main/java/com/kindtalk/server/chatroom/domain/ChatRoom.java
+++ b/src/main/java/com/kindtalk/server/chatroom/domain/ChatRoom.java
@@ -1,0 +1,41 @@
+package com.kindtalk.server.chatroom.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String title;
+
+  private String announce;
+
+  private String teacher;
+
+  @Enumerated(EnumType.STRING)
+  private Status status;
+
+  public ChatRoom(String title, String teacher) {
+    this.title = title;
+    this.announce = null;
+    this.teacher = teacher;
+    this.status = Status.ACTIVE;
+  }
+
+  public void setAnnounce(String announce) {
+    this.announce = announce;
+  }
+}

--- a/src/main/java/com/kindtalk/server/chatroom/domain/Status.java
+++ b/src/main/java/com/kindtalk/server/chatroom/domain/Status.java
@@ -1,0 +1,6 @@
+package com.kindtalk.server.chatroom.domain;
+
+public enum Status {
+  ACTIVE,
+  FROZEN
+}

--- a/src/main/java/com/kindtalk/server/chatroom/dto/ChatRoomCreateRequest.java
+++ b/src/main/java/com/kindtalk/server/chatroom/dto/ChatRoomCreateRequest.java
@@ -1,0 +1,13 @@
+package com.kindtalk.server.chatroom.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ChatRoomCreateRequest(
+  @NotBlank
+  String title,
+
+  @NotBlank
+  String teacher
+) {
+
+}

--- a/src/main/java/com/kindtalk/server/chatroom/dto/ChatRoomResponse.java
+++ b/src/main/java/com/kindtalk/server/chatroom/dto/ChatRoomResponse.java
@@ -1,0 +1,21 @@
+package com.kindtalk.server.chatroom.dto;
+
+import com.kindtalk.server.chatroom.domain.ChatRoom;
+import com.kindtalk.server.chatroom.domain.Status;
+
+public record ChatRoomResponse(
+  String title,
+  String announce,
+  String teacher,
+  Status status
+) {
+
+  public static ChatRoomResponse of(ChatRoom chatRoom) {
+    return new ChatRoomResponse(
+      chatRoom.getTitle(),
+      chatRoom.getAnnounce(),
+      chatRoom.getTeacher(),
+      chatRoom.getStatus()
+    );
+  }
+}

--- a/src/main/java/com/kindtalk/server/chatroom/dto/UpdateAnnounceRequest.java
+++ b/src/main/java/com/kindtalk/server/chatroom/dto/UpdateAnnounceRequest.java
@@ -1,5 +1,5 @@
 package com.kindtalk.server.chatroom.dto;
 
-public record UpdateAnnounceRequest(Long id, String announce) {
+public record UpdateAnnounceRequest(String announce) {
 
 }

--- a/src/main/java/com/kindtalk/server/chatroom/dto/UpdateAnnounceRequest.java
+++ b/src/main/java/com/kindtalk/server/chatroom/dto/UpdateAnnounceRequest.java
@@ -1,0 +1,5 @@
+package com.kindtalk.server.chatroom.dto;
+
+public record UpdateAnnounceRequest(Long id, String announce) {
+
+}

--- a/src/main/java/com/kindtalk/server/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/kindtalk/server/chatroom/repository/ChatRoomRepository.java
@@ -1,0 +1,8 @@
+package com.kindtalk.server.chatroom.repository;
+
+import com.kindtalk.server.chatroom.domain.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+}

--- a/src/main/java/com/kindtalk/server/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/kindtalk/server/chatroom/service/ChatRoomService.java
@@ -32,8 +32,8 @@ public class ChatRoomService {
   }
 
   @Transactional
-  public ChatRoomResponse updateAnnounce(UpdateAnnounceRequest request) {
-    ChatRoom chatRoom = chatRoomRepository.findById(request.id())
+  public ChatRoomResponse updateAnnounce(Long id, UpdateAnnounceRequest request) {
+    ChatRoom chatRoom = chatRoomRepository.findById(id)
       .orElseThrow(() -> new DataNotFoundException("해당되는 채팅방이 존재하지 않습니다."));
 
     chatRoom.setAnnounce(request.announce());

--- a/src/main/java/com/kindtalk/server/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/kindtalk/server/chatroom/service/ChatRoomService.java
@@ -24,8 +24,8 @@ public class ChatRoomService {
   }
 
   @Transactional(readOnly = true)
-  public ChatRoomResponse findById(Long Id) {
-    ChatRoom chatRoom = chatRoomRepository.findById(Id)
+  public ChatRoomResponse findById(Long id) {
+    ChatRoom chatRoom = chatRoomRepository.findById(id)
       .orElseThrow(() -> new DataNotFoundException("해당되는 채팅방이 존재하지 않습니다."));
 
     return ChatRoomResponse.of(chatRoom);

--- a/src/main/java/com/kindtalk/server/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/kindtalk/server/chatroom/service/ChatRoomService.java
@@ -1,0 +1,43 @@
+package com.kindtalk.server.chatroom.service;
+
+import com.kindtalk.server.chatroom.domain.ChatRoom;
+import com.kindtalk.server.chatroom.dto.ChatRoomCreateRequest;
+import com.kindtalk.server.chatroom.dto.ChatRoomResponse;
+import com.kindtalk.server.chatroom.dto.UpdateAnnounceRequest;
+import com.kindtalk.server.chatroom.repository.ChatRoomRepository;
+import com.kindtalk.server.exception.DataNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+  private final ChatRoomRepository chatRoomRepository;
+
+  @Transactional
+  public ChatRoomResponse create(ChatRoomCreateRequest request) {
+    ChatRoom chatRoom = new ChatRoom(request.title(), request.teacher());
+
+    return ChatRoomResponse.of(chatRoomRepository.save(chatRoom));
+  }
+
+  @Transactional(readOnly = true)
+  public ChatRoomResponse findById(Long Id) {
+    ChatRoom chatRoom = chatRoomRepository.findById(Id)
+      .orElseThrow(() -> new DataNotFoundException("해당되는 채팅방이 존재하지 않습니다."));
+
+    return ChatRoomResponse.of(chatRoom);
+  }
+
+  @Transactional
+  public ChatRoomResponse updateAnnounce(UpdateAnnounceRequest request) {
+    ChatRoom chatRoom = chatRoomRepository.findById(request.id())
+      .orElseThrow(() -> new DataNotFoundException("해당되는 채팅방이 존재하지 않습니다."));
+
+    chatRoom.setAnnounce(request.announce());
+
+    return ChatRoomResponse.of(chatRoom);
+  }
+}

--- a/src/main/java/com/kindtalk/server/exception/DataAlreadyExistsException.java
+++ b/src/main/java/com/kindtalk/server/exception/DataAlreadyExistsException.java
@@ -1,4 +1,8 @@
 package com.kindtalk.server.exception;
 
-public class DataAlreadyExistsException {
+public class DataAlreadyExistsException extends RuntimeException {
+
+  public DataAlreadyExistsException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/kindtalk/server/exception/DataAlreadyExistsException.java
+++ b/src/main/java/com/kindtalk/server/exception/DataAlreadyExistsException.java
@@ -1,0 +1,4 @@
+package com.kindtalk.server.exception;
+
+public class DataAlreadyExistsException {
+}

--- a/src/main/java/com/kindtalk/server/exception/DataNotFoundException.java
+++ b/src/main/java/com/kindtalk/server/exception/DataNotFoundException.java
@@ -1,4 +1,8 @@
 package com.kindtalk.server.exception;
 
-public class DataNotFoundException {
+public class DataNotFoundException extends RuntimeException {
+
+  public DataNotFoundException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/kindtalk/server/exception/DataNotFoundException.java
+++ b/src/main/java/com/kindtalk/server/exception/DataNotFoundException.java
@@ -1,0 +1,4 @@
+package com.kindtalk.server.exception;
+
+public class DataNotFoundException {
+}

--- a/src/main/java/com/kindtalk/server/exception/ErrorResponse.java
+++ b/src/main/java/com/kindtalk/server/exception/ErrorResponse.java
@@ -1,4 +1,7 @@
 package com.kindtalk.server.exception;
 
-public record ErrorResponse() {
+import org.springframework.http.HttpStatus;
+
+public record ErrorResponse(HttpStatus status, String message) {
+
 }

--- a/src/main/java/com/kindtalk/server/exception/ErrorResponse.java
+++ b/src/main/java/com/kindtalk/server/exception/ErrorResponse.java
@@ -1,0 +1,4 @@
+package com.kindtalk.server.exception;
+
+public record ErrorResponse() {
+}

--- a/src/main/java/com/kindtalk/server/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kindtalk/server/exception/GlobalExceptionHandler.java
@@ -1,4 +1,28 @@
 package com.kindtalk.server.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
 public class GlobalExceptionHandler {
+
+  @ExceptionHandler(value = DataAlreadyExistsException.class)
+  public ResponseEntity<ErrorResponse> handleDataAlreadyExistsException(
+    DataAlreadyExistsException e) {
+    return new ResponseEntity<>(
+      new ErrorResponse(HttpStatus.CONFLICT, e.getMessage()),
+      HttpStatus.CONFLICT
+    );
+  }
+
+  @ExceptionHandler(value = DataNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleDataNotFoundException(
+    DataNotFoundException e) {
+    return new ResponseEntity<>(
+      new ErrorResponse(HttpStatus.NOT_FOUND, e.getMessage()),
+      HttpStatus.NOT_FOUND
+    );
+  }
 }

--- a/src/main/java/com/kindtalk/server/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kindtalk/server/exception/GlobalExceptionHandler.java
@@ -1,0 +1,4 @@
+package com.kindtalk.server.exception;
+
+public class GlobalExceptionHandler {
+}

--- a/src/test/java/com/kindtalk/server/chatroom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/kindtalk/server/chatroom/service/ChatRoomServiceTest.java
@@ -68,9 +68,6 @@ public class ChatRoomServiceTest {
 
   @Test
   void 존재하지_않는_id로_조회시_실패() {
-    // given
-    ChatRoom mock = chatRoomRepository.save(new ChatRoom("채팅방3", "teacher3"));
-
     // when && then
     assertThatExceptionOfType(DataNotFoundException.class)
       .isThrownBy(() ->

--- a/src/test/java/com/kindtalk/server/chatroom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/kindtalk/server/chatroom/service/ChatRoomServiceTest.java
@@ -80,11 +80,11 @@ public class ChatRoomServiceTest {
   void 공지사항_수정_테스트() {
     // given
     ChatRoom mock = chatRoomRepository.save(new ChatRoom("채팅방4", "teacher4"));
-    UpdateAnnounceRequest request = new UpdateAnnounceRequest(mock.getId(), "공지사항");
-    ChatRoomResponse response1 = chatRoomService.findById(request.id());
+    UpdateAnnounceRequest request = new UpdateAnnounceRequest("공지사항");
+    ChatRoomResponse response1 = chatRoomService.findById(mock.getId());
 
     // when
-    chatRoomService.updateAnnounce(request);
+    chatRoomService.updateAnnounce(mock.getId(), request);
     ChatRoomResponse response2 = chatRoomService.findById(mock.getId());
 
     // then

--- a/src/test/java/com/kindtalk/server/chatroom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/kindtalk/server/chatroom/service/ChatRoomServiceTest.java
@@ -1,0 +1,34 @@
+package com.kindtalk.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kindtalk.server.chatroom.domain.Status;
+import com.kindtalk.server.chatroom.dto.ChatRoomCreateRequest;
+import com.kindtalk.server.chatroom.dto.ChatRoomResponse;
+import com.kindtalk.server.chatroom.service.ChatRoomService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class ChatRoomTest {
+
+  @Autowired
+  private ChatRoomService chatRoomService;
+
+  @Test
+  public void 채팅방_저장_테스트() {
+    // given
+    ChatRoomCreateRequest request = new ChatRoomCreateRequest("채팅방1", "teacher1");
+
+    // when
+    ChatRoomResponse response = chatRoomService.create(request);
+
+    //then
+    assertThat(response).isNotNull();
+    assertThat(response.title()).isEqualTo("채팅방1");
+    assertThat(response.announce()).isNull();
+    assertThat(response.status()).isEqualTo(Status.ACTIVE);
+    assertThat(response.teacher()).isEqualTo("teacher1");
+  }
+}

--- a/src/test/java/com/kindtalk/server/chatroom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/kindtalk/server/chatroom/service/ChatRoomServiceTest.java
@@ -1,23 +1,37 @@
-package com.kindtalk.server;
+package com.kindtalk.server.chatroom.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.kindtalk.server.chatroom.domain.ChatRoom;
 import com.kindtalk.server.chatroom.domain.Status;
 import com.kindtalk.server.chatroom.dto.ChatRoomCreateRequest;
 import com.kindtalk.server.chatroom.dto.ChatRoomResponse;
-import com.kindtalk.server.chatroom.service.ChatRoomService;
+import com.kindtalk.server.chatroom.dto.UpdateAnnounceRequest;
+import com.kindtalk.server.chatroom.repository.ChatRoomRepository;
+import com.kindtalk.server.exception.DataNotFoundException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-public class ChatRoomTest {
+public class ChatRoomServiceTest {
 
   @Autowired
   private ChatRoomService chatRoomService;
 
+  @Autowired
+  private ChatRoomRepository chatRoomRepository;
+
+  @AfterEach
+  void tearDown() {
+    chatRoomRepository.deleteAll();
+  }
+
   @Test
-  public void 채팅방_저장_테스트() {
+  void 채팅방_저장_테스트() {
     // given
     ChatRoomCreateRequest request = new ChatRoomCreateRequest("채팅방1", "teacher1");
 
@@ -25,10 +39,65 @@ public class ChatRoomTest {
     ChatRoomResponse response = chatRoomService.create(request);
 
     //then
-    assertThat(response).isNotNull();
-    assertThat(response.title()).isEqualTo("채팅방1");
-    assertThat(response.announce()).isNull();
-    assertThat(response.status()).isEqualTo(Status.ACTIVE);
-    assertThat(response.teacher()).isEqualTo("teacher1");
+    assertAll(
+      () -> assertThat(response).isNotNull(),
+      () -> assertThat(response.title()).isEqualTo("채팅방1"),
+      () -> assertThat(response.announce()).isNull(),
+      () -> assertThat(response.status()).isEqualTo(Status.ACTIVE),
+      () -> assertThat(response.teacher()).isEqualTo("teacher1")
+    );
+  }
+
+  @Test
+  void 채팅방_조회_테스트() {
+    // given
+    ChatRoom mock = chatRoomRepository.save(new ChatRoom("채팅방2", "teacher2"));
+
+    // when
+    ChatRoomResponse response = chatRoomService.findById(mock.getId());
+
+    // then
+    assertAll(
+      () -> assertThat(response).isNotNull(),
+      () -> assertThat(response.title()).isEqualTo("채팅방2"),
+      () -> assertThat(response.announce()).isNull(),
+      () -> assertThat(response.status()).isEqualTo(Status.ACTIVE),
+      () -> assertThat(response.teacher()).isEqualTo("teacher2")
+    );
+  }
+
+  @Test
+  void 존재하지_않는_id로_조회시_실패() {
+    // given
+    ChatRoom mock = chatRoomRepository.save(new ChatRoom("채팅방3", "teacher3"));
+
+    // when && then
+    assertThatExceptionOfType(DataNotFoundException.class)
+      .isThrownBy(() ->
+        chatRoomService.findById(100L)
+      )
+      .withMessage("해당되는 채팅방이 존재하지 않습니다.");
+  }
+
+  @Test
+  void 공지사항_수정_테스트() {
+    // given
+    ChatRoom mock = chatRoomRepository.save(new ChatRoom("채팅방4", "teacher4"));
+    UpdateAnnounceRequest request = new UpdateAnnounceRequest(mock.getId(), "공지사항");
+    ChatRoomResponse response1 = chatRoomService.findById(request.id());
+
+    // when
+    chatRoomService.updateAnnounce(request);
+    ChatRoomResponse response2 = chatRoomService.findById(mock.getId());
+
+    // then
+    assertAll(
+      () -> assertThat(response1).isNotNull(),
+      () -> assertThat(response1.announce()).isNull(),
+      () -> assertThat(response2).isNotNull(),
+      () -> assertThat(response2.title()).isEqualTo("채팅방4"),
+      () -> assertThat(response2.teacher()).isEqualTo("teacher4"),
+      () -> assertThat(response2.announce()).isEqualTo("공지사항")
+    );
   }
 }


### PR DESCRIPTION
close #1 

## 주요 구현 사항
채팅방과 관련된 주요 CRUD 로직을 구현하였습니다.

개발 초기 단계이기 때문에 진행하면서 많은 변경점이 존재하겠지만 가장 기본적인 뼈대를 구현해보고자 했습니다.

### 1. 채팅방 저장
채팅방의 이름과 담임 선생님의 이름을 받도록 하였습니다.
Member 도메인이 추가가 되면 연관관계 매핑을 통해 담임 선생님은 해당 타입으로 받도록 수정할 것입니다.
저장시 http status 코드는 201 created로 설정하였습니다.

### 2. 채팅방 조회
채팅방의 id로 채팅방을 조회할 수 있도록 하였습니다.
만약 존재하지 않는 채팅방의 id를 조회한 경우 DataNotFoundException 예외를 호출하여 `NOT_FOUND`를 반환하도록 하였습니다.

### 3. 공지사항 업데이트
채팅방의 공지사항을 업데이트 할 수 있도록 하였습니다.
~~다른 patch 메서드는 존재하지 않기 때문에 엔드포인트는 우선 기본(`/api/chatroom`)으로 설정해두었습니다. 채팅방 조회와는 다르게 body에서 id를 불러오도록 하였습니다.~~
코드 리뷰에 따라 pathvariable로 id를 불러오게끔 수정하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat room creation with title and teacher
  * Retrieve chat rooms by ID with full details
  * Update chat room announcements
  * Chat room status tracking (active / frozen)
  * Automatic data auditing (timestamps for records)

* **Bug Fixes**
  * Consistent API error responses for missing or duplicate chat rooms (404 / 409)

* **Tests**
  * Added integration tests covering create, read, update, and error cases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->