### PR TITLE
Feat/chat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.7'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.7'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.kindtalk'
@@ -9,36 +9,37 @@ version = '0.0.1-SNAPSHOT'
 description = 'Demo project for Spring Boot'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/kindtalk/server/ServerApplication.java
+++ b/src/main/java/com/kindtalk/server/ServerApplication.java
@@ -2,10 +2,8 @@ package com.kindtalk.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class ServerApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/kindtalk/server/chat/document/Message.java
+++ b/src/main/java/com/kindtalk/server/chat/document/Message.java
@@ -1,0 +1,4 @@
+package com.kindtalk.server.chat.document;
+
+public class message {
+}

--- a/src/main/java/com/kindtalk/server/chat/document/Message.java
+++ b/src/main/java/com/kindtalk/server/chat/document/Message.java
@@ -1,4 +1,0 @@
-package com.kindtalk.server.chat.document;
-
-public class message {
-}

--- a/src/main/java/com/kindtalk/server/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/kindtalk/server/chatroom/controller/ChatRoomController.java
@@ -4,7 +4,10 @@ import com.kindtalk.server.chatroom.dto.ChatRoomCreateRequest;
 import com.kindtalk.server.chatroom.dto.ChatRoomResponse;
 import com.kindtalk.server.chatroom.dto.UpdateAnnounceRequest;
 import com.kindtalk.server.chatroom.service.ChatRoomService;
+import com.kindtalk.server.message.dto.MessageResponse;
+import com.kindtalk.server.message.service.MessageService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatRoomController {
 
   private final ChatRoomService chatRoomService;
+  private final MessageService messageService;
 
   @PostMapping
   public ResponseEntity<ChatRoomResponse> create(
@@ -40,5 +44,10 @@ public class ChatRoomController {
     @PathVariable Long id,
     @RequestBody UpdateAnnounceRequest request) {
     return ResponseEntity.ok(chatRoomService.updateAnnounce(id, request));
+  }
+
+  @GetMapping("/{roomId}/messages")
+  public List<MessageResponse> getHistory(@PathVariable Long roomId) {
+    return messageService.getHistory(roomId);
   }
 }

--- a/src/main/java/com/kindtalk/server/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/kindtalk/server/chatroom/controller/ChatRoomController.java
@@ -47,7 +47,7 @@ public class ChatRoomController {
   }
 
   @GetMapping("/{roomId}/messages")
-  public List<MessageResponse> getHistory(@PathVariable Long roomId) {
-    return messageService.getHistory(roomId);
+  public ResponseEntity<List<MessageResponse>> getHistory(@PathVariable Long roomId) {
+    return ResponseEntity.ok(messageService.getHistory(roomId));
   }
 }

--- a/src/main/java/com/kindtalk/server/config/WebSocketConfig.java
+++ b/src/main/java/com/kindtalk/server/config/WebSocketConfig.java
@@ -13,7 +13,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     registry.addEndpoint("/websocket")
-      .setAllowedOrigins("*")
+      .setAllowedOriginPatterns("*")
       .withSockJS();
   }
 

--- a/src/main/java/com/kindtalk/server/config/WebSocketConfig.java
+++ b/src/main/java/com/kindtalk/server/config/WebSocketConfig.java
@@ -1,0 +1,5 @@
+package com.kindtalk.server.config.security;
+
+public class WebSocketConfig {
+
+}

--- a/src/main/java/com/kindtalk/server/config/WebSocketConfig.java
+++ b/src/main/java/com/kindtalk/server/config/WebSocketConfig.java
@@ -1,5 +1,25 @@
-package com.kindtalk.server.config.security;
+package com.kindtalk.server.config;
 
-public class WebSocketConfig {
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/websocket")
+      .setAllowedOrigins("*")
+      .withSockJS();
+  }
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    registry.enableSimpleBroker("/sub");
+    registry.setApplicationDestinationPrefixes("/pub");
+  }
 }

--- a/src/main/java/com/kindtalk/server/message/controller/MessageController.java
+++ b/src/main/java/com/kindtalk/server/message/controller/MessageController.java
@@ -1,0 +1,26 @@
+package com.kindtalk.server.message.controller;
+
+import com.kindtalk.server.message.dto.MessageRequest;
+import com.kindtalk.server.message.dto.MessageResponse;
+import com.kindtalk.server.message.service.MessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class MessageController {
+
+  private final MessageService messageService;
+
+  @MessageMapping("/chat.{roomId}")
+  @SendTo("/sub/chat.{roomId}")
+  public MessageResponse send(
+    @DestinationVariable Long roomId,
+    MessageRequest request
+  ) {
+    return messageService.saveAndSend(roomId, request);
+  }
+}

--- a/src/main/java/com/kindtalk/server/message/controller/MessageController.java
+++ b/src/main/java/com/kindtalk/server/message/controller/MessageController.java
@@ -3,6 +3,7 @@ package com.kindtalk.server.message.controller;
 import com.kindtalk.server.message.dto.MessageRequest;
 import com.kindtalk.server.message.dto.MessageResponse;
 import com.kindtalk.server.message.service.MessageService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -20,7 +21,7 @@ public class MessageController {
   @SendTo("/sub/chat.{roomId}")
   public MessageResponse send(
     @DestinationVariable Long roomId,
-    @Payload MessageRequest request
+    @Valid @Payload MessageRequest request
   ) {
     return messageService.saveAndSend(roomId, request);
   }

--- a/src/main/java/com/kindtalk/server/message/controller/MessageController.java
+++ b/src/main/java/com/kindtalk/server/message/controller/MessageController.java
@@ -6,6 +6,7 @@ import com.kindtalk.server.message.service.MessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
 
@@ -19,7 +20,7 @@ public class MessageController {
   @SendTo("/sub/chat.{roomId}")
   public MessageResponse send(
     @DestinationVariable Long roomId,
-    MessageRequest request
+    @Payload MessageRequest request
   ) {
     return messageService.saveAndSend(roomId, request);
   }

--- a/src/main/java/com/kindtalk/server/message/document/Message.java
+++ b/src/main/java/com/kindtalk/server/message/document/Message.java
@@ -10,7 +10,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 public class Message {
 
   @Id
-  private Long id;
+  private String id;
 
   private Long roomId;
   private Long senderId;

--- a/src/main/java/com/kindtalk/server/message/document/Message.java
+++ b/src/main/java/com/kindtalk/server/message/document/Message.java
@@ -1,0 +1,17 @@
+package com.kindtalk.server.chat.document;
+
+import jakarta.persistence.Id;
+import java.time.Instant;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "chat_message")
+public class Message {
+
+  @Id
+  private String id;
+
+  private Long roomId;
+  private String senderId;
+  private String content;
+  private Instant sendAt;
+}

--- a/src/main/java/com/kindtalk/server/message/document/Message.java
+++ b/src/main/java/com/kindtalk/server/message/document/Message.java
@@ -1,8 +1,8 @@
 package com.kindtalk.server.message.document;
 
-import jakarta.persistence.Id;
 import java.time.Instant;
 import lombok.Getter;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter

--- a/src/main/java/com/kindtalk/server/message/document/Message.java
+++ b/src/main/java/com/kindtalk/server/message/document/Message.java
@@ -1,17 +1,26 @@
-package com.kindtalk.server.chat.document;
+package com.kindtalk.server.message.document;
 
 import jakarta.persistence.Id;
 import java.time.Instant;
+import lombok.Getter;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+@Getter
 @Document(collection = "chat_message")
 public class Message {
 
   @Id
-  private String id;
+  private Long id;
 
   private Long roomId;
-  private String senderId;
+  private Long senderId;
   private String content;
   private Instant sendAt;
+
+  public Message(Long roomId, Long senderId, String content, Instant sendAt) {
+    this.roomId = roomId;
+    this.senderId = senderId;
+    this.content = content;
+    this.sendAt = sendAt;
+  }
 }

--- a/src/main/java/com/kindtalk/server/message/document/Message.java
+++ b/src/main/java/com/kindtalk/server/message/document/Message.java
@@ -3,6 +3,7 @@ package com.kindtalk.server.message.document;
 import java.time.Instant;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
@@ -12,6 +13,7 @@ public class Message {
   @Id
   private String id;
 
+  @Indexed
   private Long roomId;
   private Long senderId;
   private String content;

--- a/src/main/java/com/kindtalk/server/message/dto/MessageRequest.java
+++ b/src/main/java/com/kindtalk/server/message/dto/MessageRequest.java
@@ -1,5 +1,5 @@
 package com.kindtalk.server.message.dto;
 
-public record MessageRequest(Long roomId, Long senderId, String content) {
+public record MessageRequest(Long senderId, String content) {
   
 }

--- a/src/main/java/com/kindtalk/server/message/dto/MessageRequest.java
+++ b/src/main/java/com/kindtalk/server/message/dto/MessageRequest.java
@@ -1,5 +1,13 @@
 package com.kindtalk.server.message.dto;
 
-public record MessageRequest(Long senderId, String content) {
-  
+import jakarta.validation.constraints.NotBlank;
+
+public record MessageRequest(
+  @NotBlank
+  Long senderId,
+
+  @NotBlank
+  String content
+) {
+
 }

--- a/src/main/java/com/kindtalk/server/message/dto/MessageRequest.java
+++ b/src/main/java/com/kindtalk/server/message/dto/MessageRequest.java
@@ -1,0 +1,5 @@
+package com.kindtalk.server.message.dto;
+
+public record MessageRequest(Long roomId, Long senderId, String content) {
+  
+}

--- a/src/main/java/com/kindtalk/server/message/dto/MessageResponse.java
+++ b/src/main/java/com/kindtalk/server/message/dto/MessageResponse.java
@@ -1,0 +1,16 @@
+package com.kindtalk.server.message.dto;
+
+import com.kindtalk.server.message.document.Message;
+import java.time.Instant;
+
+public record MessageResponse(Long roomId, Long senderId, String content, Instant sendAt) {
+
+  public static MessageResponse of(Message message) {
+    return new MessageResponse(
+      message.getRoomId(),
+      message.getSenderId(),
+      message.getContent(),
+      message.getSendAt()
+    );
+  }
+}

--- a/src/main/java/com/kindtalk/server/message/repository/MessageRepository.java
+++ b/src/main/java/com/kindtalk/server/message/repository/MessageRepository.java
@@ -1,0 +1,4 @@
+package com.kindtalk.server.chat.repository;
+
+public class ChatRepository {
+}

--- a/src/main/java/com/kindtalk/server/message/repository/MessageRepository.java
+++ b/src/main/java/com/kindtalk/server/message/repository/MessageRepository.java
@@ -1,4 +1,10 @@
-package com.kindtalk.server.chat.repository;
+package com.kindtalk.server.message.repository;
 
-public class ChatRepository {
+import com.kindtalk.server.message.document.Message;
+import java.util.List;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface MessageRepository extends MongoRepository<Message, String> {
+
+  List<Message> findAllByRoomIdOrderBySendAtAsc(Long roomId);
 }

--- a/src/main/java/com/kindtalk/server/message/service/MessageService.java
+++ b/src/main/java/com/kindtalk/server/message/service/MessageService.java
@@ -1,0 +1,31 @@
+package com.kindtalk.server.message.service;
+
+import com.kindtalk.server.message.document.Message;
+import com.kindtalk.server.message.dto.MessageRequest;
+import com.kindtalk.server.message.dto.MessageResponse;
+import com.kindtalk.server.message.repository.MessageRepository;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+  private final MessageRepository messageRepository;
+
+  public MessageResponse saveAndSend(Long roomId, MessageRequest request) {
+    Message message = messageRepository.save(
+      new Message(roomId, request.senderId(), request.content(), Instant.now())
+    );
+
+    return MessageResponse.of(message);
+  }
+
+  public List<MessageResponse> getHistory(Long roomId) {
+    return messageRepository.findAllByRoomIdOrderBySendAtAsc(roomId).stream()
+      .map(MessageResponse::of)
+      .toList();
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,12 @@
+spring:
+  data:
+    mongodb:
+      uri: mongodb://root:1234@localhost:27017/chat?authSource=admin
+
+debug: true
+
+logging:
+  level:
+    org.springframework.web.socket: DEBUG
+    org.springframework.messaging: DEBUG
+    org.springframework.stomp: DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=server

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: dev


### PR DESCRIPTION
close #6 

## 구현 내용
STOMP를 사용해서 채팅 서비스를 간략하게 구현하였습니다.

- 채팅 메세지를 저장하는 DB로는 mongoDB를 사용했습니다.
- roomId를 사용해서 채팅방을 구분하여 메세지를 전송할 수 있도록 하였습니다.
- 채팅 메세지를 보낼 때 동시에 DB에 저장할 수 있도록 하였습니다.
- 채팅 메세지를 불러오는 api를 구현하였습니다.
    - 채팅 메세지가 많아지는 경우 성능 문제를 초래할 수 있으므로 추후 무한 스크롤 구현을 통해 이를 해결할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time messaging via WebSocket/STOMP
  * Endpoint to retrieve chat room message history
  * Message persistence and send/receive flow

* **Chores**
  * Added MongoDB support and updated dependencies
  * Development configuration updated for local dev/debug environment

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->