### PR TITLE
Feat/member

### DIFF
--- a/src/main/java/com/kindtalk/server/exception/BadRequestException.java
+++ b/src/main/java/com/kindtalk/server/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package com.kindtalk.server.exception;
+
+public class BadRequestException extends RuntimeException {
+  
+  public BadRequestException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/kindtalk/server/exception/BadRequestException.java
+++ b/src/main/java/com/kindtalk/server/exception/BadRequestException.java
@@ -1,8 +1,0 @@
-package com.kindtalk.server.exception;
-
-public class BadRequestException extends RuntimeException {
-  
-  public BadRequestException(String message) {
-    super(message);
-  }
-}

--- a/src/main/java/com/kindtalk/server/exception/BusinessRuleException.java
+++ b/src/main/java/com/kindtalk/server/exception/BusinessRuleException.java
@@ -1,0 +1,8 @@
+package com.kindtalk.server.exception;
+
+public class BusinessRuleException extends RuntimeException {
+
+  public BusinessRuleException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/kindtalk/server/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kindtalk/server/exception/GlobalExceptionHandler.java
@@ -39,6 +39,15 @@ public class GlobalExceptionHandler {
     );
   }
 
+  @ExceptionHandler(value = BadRequestException.class)
+  public ResponseEntity<ErrorResponse> handleBadRequestException(
+    BadRequestException e) {
+    return new ResponseEntity<>(
+      new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage()),
+      HttpStatus.BAD_REQUEST
+    );
+  }
+
   @ExceptionHandler(value = MethodArgumentNotValidException.class)
   public ResponseEntity<ValidationResponse> handleMethodArgumentNotValidException(
     MethodArgumentNotValidException e) {

--- a/src/main/java/com/kindtalk/server/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kindtalk/server/exception/GlobalExceptionHandler.java
@@ -39,9 +39,9 @@ public class GlobalExceptionHandler {
     );
   }
 
-  @ExceptionHandler(value = BadRequestException.class)
+  @ExceptionHandler(value = BusinessRuleException.class)
   public ResponseEntity<ErrorResponse> handleBadRequestException(
-    BadRequestException e) {
+    BusinessRuleException e) {
     return new ResponseEntity<>(
       new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage()),
       HttpStatus.BAD_REQUEST

--- a/src/main/java/com/kindtalk/server/member/controller/MemberController.java
+++ b/src/main/java/com/kindtalk/server/member/controller/MemberController.java
@@ -4,6 +4,7 @@ package com.kindtalk.server.member.controller;
 import com.kindtalk.server.member.dto.MemberJoinRequest;
 import com.kindtalk.server.member.dto.MemberResponse;
 import com.kindtalk.server.member.dto.MemberUpdateRequest;
+import com.kindtalk.server.member.dto.TeacherSchoolUpdateRequest;
 import com.kindtalk.server.member.service.MemberService;
 import com.kindtalk.server.security.principal.MyUserDetails;
 import jakarta.validation.Valid;
@@ -39,5 +40,12 @@ public class MemberController {
     @AuthenticationPrincipal MyUserDetails member,
     @Valid @RequestBody MemberUpdateRequest updateRequest) {
     return ResponseEntity.ok(memberService.memberUpdate(member, updateRequest));
+  }
+
+  @PatchMapping("/me/school")
+  public ResponseEntity<MemberResponse> updateSchool(
+    @AuthenticationPrincipal MyUserDetails auth,
+    @Valid @RequestBody TeacherSchoolUpdateRequest request) {
+    return ResponseEntity.ok(memberService.updateSchool(auth, request));
   }
 }

--- a/src/main/java/com/kindtalk/server/member/domain/Member.java
+++ b/src/main/java/com/kindtalk/server/member/domain/Member.java
@@ -1,6 +1,7 @@
 package com.kindtalk.server.member.domain;
 
 import com.kindtalk.server.member.role.Role;
+import com.kindtalk.server.school.domain.School;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -19,20 +20,29 @@ public class Member {
   private String password;
   private String userName;
   private String nickName;
-  
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "school_code")
+  private School school;
+
   @Enumerated(EnumType.STRING)
   private Role role;
 
-  public Member(String email, String password, String userName, String nickName, Role role) {
+  public Member(String email, String password, String userName, String nickName, School school, Role role) {
     this.email = email;
     this.password = password;
     this.userName = userName;
     this.nickName = nickName;
+    this.school = school;
     this.role = role;
   }
 
   public void updateInfo(String userName, String nickName) {
     this.userName = userName;
     this.nickName = nickName;
+  }
+
+  public void updateSchool(School school) {
+    this.school = school;
   }
 }

--- a/src/main/java/com/kindtalk/server/member/dto/MemberJoinRequest.java
+++ b/src/main/java/com/kindtalk/server/member/dto/MemberJoinRequest.java
@@ -2,6 +2,7 @@ package com.kindtalk.server.member.dto;
 
 import com.kindtalk.server.member.domain.Member;
 import com.kindtalk.server.member.role.Role;
+import com.kindtalk.server.school.domain.School;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -14,19 +15,22 @@ public record MemberJoinRequest(
 
   @NotBlank
   String userName,
-  
+
   @NotBlank
   String nickName,
+
+  String schoolCode,
 
   @NotNull
   Role role) {
 
-  public Member toEntity(String password) {
+  public Member toEntity(String password, School school) {
     return new Member(
       this.email,
       password,
       this.userName,
       this.nickName,
+      school,
       this.role
     );
   }

--- a/src/main/java/com/kindtalk/server/member/dto/MemberResponse.java
+++ b/src/main/java/com/kindtalk/server/member/dto/MemberResponse.java
@@ -13,11 +13,11 @@ public record MemberResponse(
   Role role) {
 
   public static MemberResponse of(Member member) {
-    boolean isTeacher = member.getRole() == Role.TEACHER;
     School school = member.getSchool();
+    boolean isTeacherWithSchool = member.getRole() == Role.TEACHER && school != null;
 
-    String schoolCode = (isTeacher && school != null) ? school.getCode() : null;
-    String schoolName = (isTeacher && school != null) ? school.getName() : null;
+    String schoolCode = isTeacherWithSchool ? school.getCode() : null;
+    String schoolName = isTeacherWithSchool ? school.getName() : null;
 
     return new MemberResponse(
       member.getEmail(),

--- a/src/main/java/com/kindtalk/server/member/dto/MemberResponse.java
+++ b/src/main/java/com/kindtalk/server/member/dto/MemberResponse.java
@@ -2,18 +2,29 @@ package com.kindtalk.server.member.dto;
 
 import com.kindtalk.server.member.domain.Member;
 import com.kindtalk.server.member.role.Role;
+import com.kindtalk.server.school.domain.School;
 
 public record MemberResponse(
   String email,
   String userName,
   String nickName,
+  String schoolCode,
+  String schoolName,
   Role role) {
 
   public static MemberResponse of(Member member) {
+    boolean isTeacher = member.getRole() == Role.TEACHER;
+    School school = member.getSchool();
+
+    String schoolCode = (isTeacher && school != null) ? school.getCode() : null;
+    String schoolName = (isTeacher && school != null) ? school.getName() : null;
+
     return new MemberResponse(
       member.getEmail(),
       member.getUserName(),
       member.getNickName(),
+      schoolCode,
+      schoolName,
       member.getRole()
     );
   }

--- a/src/main/java/com/kindtalk/server/member/dto/TeacherSchoolUpdateRequest.java
+++ b/src/main/java/com/kindtalk/server/member/dto/TeacherSchoolUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.kindtalk.server.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TeacherSchoolUpdateRequest(
+  @NotBlank
+  String schoolCode) {
+}

--- a/src/main/java/com/kindtalk/server/member/role/Role.java
+++ b/src/main/java/com/kindtalk/server/member/role/Role.java
@@ -1,5 +1,5 @@
 package com.kindtalk.server.member.role;
 
 public enum Role {
-  TEACHER, MEMBER
+  TEACHER, PARENT
 }

--- a/src/main/java/com/kindtalk/server/member/service/MemberService.java
+++ b/src/main/java/com/kindtalk/server/member/service/MemberService.java
@@ -1,6 +1,6 @@
 package com.kindtalk.server.member.service;
 
-import com.kindtalk.server.exception.BadRequestException;
+import com.kindtalk.server.exception.BusinessRuleException;
 import com.kindtalk.server.exception.DataAlreadyExistsException;
 import com.kindtalk.server.exception.DataNotFoundException;
 import com.kindtalk.server.member.domain.Member;
@@ -35,8 +35,8 @@ public class MemberService {
     School school = null;
     if (join.role() == Role.TEACHER) {
       if (join.schoolCode() == null || join.schoolCode().isBlank())
-        throw new BadRequestException("선생님 권한에서 학교는 필수입니다.");
-      
+        throw new BusinessRuleException("선생님 권한에서 학교는 필수입니다.");
+
       school = findSchool(join.schoolCode());
     }
 
@@ -72,7 +72,7 @@ public class MemberService {
   public MemberResponse updateSchool(MyUserDetails auth, TeacherSchoolUpdateRequest request) {
     Member member = findById(auth.getMemberId());
 
-    if (member.getRole() != Role.TEACHER) throw new BadRequestException("선생님만 학교 정보를 수정할 수 있습니다.");
+    if (member.getRole() != Role.TEACHER) throw new BusinessRuleException("선생님만 학교 정보를 수정할 수 있습니다.");
 
     School school = findSchool(request.schoolCode());
     member.updateSchool(school);

--- a/src/main/java/com/kindtalk/server/member/service/MemberService.java
+++ b/src/main/java/com/kindtalk/server/member/service/MemberService.java
@@ -34,7 +34,9 @@ public class MemberService {
 
     School school = null;
     if (join.role() == Role.TEACHER) {
-      if (join.schoolCode() == null) throw new BadRequestException("선생님 권한에서 학교는 필수입니다.");
+      if (join.schoolCode() == null || join.schoolCode().isBlank())
+        throw new BadRequestException("선생님 권한에서 학교는 필수입니다.");
+      
       school = findSchool(join.schoolCode());
     }
 
@@ -71,7 +73,7 @@ public class MemberService {
     Member member = findById(auth.getMemberId());
 
     if (member.getRole() != Role.TEACHER) throw new BadRequestException("선생님만 학교 정보를 수정할 수 있습니다.");
-    
+
     School school = findSchool(request.schoolCode());
     member.updateSchool(school);
     return MemberResponse.of(member);

--- a/src/main/java/com/kindtalk/server/member/service/MemberService.java
+++ b/src/main/java/com/kindtalk/server/member/service/MemberService.java
@@ -69,6 +69,9 @@ public class MemberService {
   @Transactional
   public MemberResponse updateSchool(MyUserDetails auth, TeacherSchoolUpdateRequest request) {
     Member member = findById(auth.getMemberId());
+
+    if (member.getRole() != Role.TEACHER) throw new BadRequestException("선생님만 학교 정보를 수정할 수 있습니다.");
+    
     School school = findSchool(request.schoolCode());
     member.updateSchool(school);
     return MemberResponse.of(member);

--- a/src/main/java/com/kindtalk/server/member/service/MemberService.java
+++ b/src/main/java/com/kindtalk/server/member/service/MemberService.java
@@ -1,12 +1,17 @@
 package com.kindtalk.server.member.service;
 
+import com.kindtalk.server.exception.BadRequestException;
 import com.kindtalk.server.exception.DataAlreadyExistsException;
 import com.kindtalk.server.exception.DataNotFoundException;
 import com.kindtalk.server.member.domain.Member;
 import com.kindtalk.server.member.dto.MemberJoinRequest;
 import com.kindtalk.server.member.dto.MemberResponse;
 import com.kindtalk.server.member.dto.MemberUpdateRequest;
+import com.kindtalk.server.member.dto.TeacherSchoolUpdateRequest;
 import com.kindtalk.server.member.repository.MemberRepository;
+import com.kindtalk.server.member.role.Role;
+import com.kindtalk.server.school.domain.School;
+import com.kindtalk.server.school.repository.SchoolRepository;
 import com.kindtalk.server.security.principal.MyUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -18,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
   private final MemberRepository memberRepository;
+  private final SchoolRepository schoolRepository;
   private final PasswordEncoder passwordEncoder;
 
   @Transactional
@@ -25,9 +31,21 @@ public class MemberService {
     if (memberRepository.existsByEmail(join.email())) {
       throw new DataAlreadyExistsException("이미 존재하는 회원입니다.");
     }
+
+    School school = null;
+    if (join.role() == Role.TEACHER) {
+      if (join.schoolCode() == null) throw new BadRequestException("선생님 권한에서 학교는 필수입니다.");
+      school = findSchool(join.schoolCode());
+    }
+
     String password = passwordEncoder.encode(join.password());
-    Member member = memberRepository.save(join.toEntity(password));
+    Member member = memberRepository.save(join.toEntity(password, school));
     return MemberResponse.of(member);
+  }
+
+  private School findSchool(String schoolCode) {
+    return schoolRepository.findById(schoolCode)
+      .orElseThrow(() -> new DataNotFoundException("해당 학교가 존재하지 않습니다."));
   }
 
   @Transactional(readOnly = true)
@@ -46,5 +64,13 @@ public class MemberService {
   private Member findById(Long id) {
     return memberRepository.findById(id)
       .orElseThrow(() -> new DataNotFoundException("해당 회원이 존재하지 않습니다."));
+  }
+
+  @Transactional
+  public MemberResponse updateSchool(MyUserDetails auth, TeacherSchoolUpdateRequest request) {
+    Member member = findById(auth.getMemberId());
+    School school = findSchool(request.schoolCode());
+    member.updateSchool(school);
+    return MemberResponse.of(member);
   }
 }

--- a/src/main/java/com/kindtalk/server/security/principal/MyUserDetails.java
+++ b/src/main/java/com/kindtalk/server/security/principal/MyUserDetails.java
@@ -23,6 +23,10 @@ public class MyUserDetails implements UserDetails {
     return member;
   }
 
+  public Long getMemberId() {
+    return member.getId();
+  }
+
   @Override
   public String getUsername() {
     return member.getEmail();

--- a/src/test/java/com/kindtalk/server/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kindtalk/server/member/service/MemberServiceTest.java
@@ -1,6 +1,6 @@
 package com.kindtalk.server.member.service;
 
-import com.kindtalk.server.exception.BadRequestException;
+import com.kindtalk.server.exception.BusinessRuleException;
 import com.kindtalk.server.exception.DataAlreadyExistsException;
 import com.kindtalk.server.exception.DataNotFoundException;
 import com.kindtalk.server.member.domain.Member;
@@ -78,7 +78,7 @@ public class MemberServiceTest {
     MemberJoinRequest request = new MemberJoinRequest("m2@email.com", "1234", "회원2", "별명2", null, Role.TEACHER);
 
     // when & then
-    BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+    BusinessRuleException exception = assertThrows(BusinessRuleException.class, () -> {
       memberService.memberJoin(request);
     });
     assertThat(exception.getMessage()).isEqualTo("선생님 권한에서 학교는 필수입니다.");

--- a/src/test/java/com/kindtalk/server/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kindtalk/server/member/service/MemberServiceTest.java
@@ -1,13 +1,17 @@
 package com.kindtalk.server.member.service;
 
+import com.kindtalk.server.exception.BadRequestException;
 import com.kindtalk.server.exception.DataAlreadyExistsException;
 import com.kindtalk.server.exception.DataNotFoundException;
 import com.kindtalk.server.member.domain.Member;
 import com.kindtalk.server.member.dto.MemberJoinRequest;
 import com.kindtalk.server.member.dto.MemberResponse;
 import com.kindtalk.server.member.dto.MemberUpdateRequest;
+import com.kindtalk.server.member.dto.TeacherSchoolUpdateRequest;
 import com.kindtalk.server.member.repository.MemberRepository;
 import com.kindtalk.server.member.role.Role;
+import com.kindtalk.server.school.domain.School;
+import com.kindtalk.server.school.repository.SchoolRepository;
 import com.kindtalk.server.security.principal.MyUserDetails;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,12 +19,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
+@ActiveProfiles("test")
 public class MemberServiceTest {
 
   @Autowired
@@ -30,17 +37,24 @@ public class MemberServiceTest {
   MemberRepository memberRepository;
 
   @Autowired
+  SchoolRepository schoolRepository;
+
+  @Autowired
   PasswordEncoder passwordEncoder;
 
-  MemberJoinRequest member;
+  private MemberJoinRequest member;
+  private School school;
 
   @BeforeEach
   void setUp() {
+    school = schoolRepository.save(new School("12345", "테스트 초등학교"));
+
     member = new MemberJoinRequest(
       "m1@email.com",
       "11",
       "박땡땡",
       "박맘",
+      school.getCode(),
       Role.TEACHER
     );
   }
@@ -62,8 +76,7 @@ public class MemberServiceTest {
 
   @Test
   void 중복회원_테스트() {
-    String password = passwordEncoder.encode(member.password());
-    memberRepository.save(member.toEntity(password));
+    memberRepository.save(new Member("m1@email.com", "11", "박땡땡", "박맘", school, Role.TEACHER));
 
     DataAlreadyExistsException exception = assertThrows(DataAlreadyExistsException.class, () -> {
       memberService.memberJoin(member);
@@ -72,9 +85,21 @@ public class MemberServiceTest {
   }
 
   @Test
+  void 선생님_학교_누락_시_회원가입_실패() {
+    // given
+    MemberJoinRequest request = new MemberJoinRequest("m1@email.com", "11", "회원1", "별명1", null, Role.TEACHER);
+
+    // when & then
+    BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+      memberService.memberJoin(request);
+    });
+    assertThat(exception.getMessage()).isEqualTo("선생님 권한에서 학교는 필수입니다.");
+  }
+
+  @Test
   void 회원조회_테스트() {
     String password = passwordEncoder.encode(member.password());
-    Member memberData = memberRepository.save(member.toEntity(password));
+    Member memberData = memberRepository.save(member.toEntity(password, school));
 
     MyUserDetails userDetails = new MyUserDetails(memberData);
 
@@ -89,7 +114,7 @@ public class MemberServiceTest {
   @Test
   void 회원수정_테스트() {
     String password = passwordEncoder.encode(member.password());
-    Member memberData = memberRepository.save(member.toEntity(password));
+    Member memberData = memberRepository.save(member.toEntity(password, school));
 
     MyUserDetails userDetails = new MyUserDetails(memberData);
 
@@ -105,7 +130,7 @@ public class MemberServiceTest {
   @Test
   void 없는_회원_조회하기_테스트() {
     String password = passwordEncoder.encode(member.password());
-    Member memberEntity = member.toEntity(password);
+    Member memberEntity = member.toEntity(password, school); // ???
 
     ReflectionTestUtils.setField(memberEntity, "id", 100L);
     MyUserDetails userDetails = new MyUserDetails(memberEntity);
@@ -114,5 +139,24 @@ public class MemberServiceTest {
       memberService.memberDetail(userDetails);
     });
     assertThat(exception.getMessage()).isEqualTo("해당 회원이 존재하지 않습니다.");
+  }
+
+  @Test
+  void 선생님_학교_수정_테스트() {
+    // given
+    schoolRepository.save(new School("22222", "테스트2 초등학교"));
+    Member member = memberRepository.save(new Member("m1@email.com", "1234", "회원1", "별명1", school, Role.TEACHER));
+
+    TeacherSchoolUpdateRequest request = new TeacherSchoolUpdateRequest("22222");
+    MyUserDetails auth = new MyUserDetails(member);
+
+    // when
+    MemberResponse response = memberService.updateSchool(auth, request);
+
+    // then
+    assertAll(
+      () -> assertThat(response.schoolCode()).isEqualTo("22222"),
+      () -> assertThat(response.schoolName()).isEqualTo("테스트2 초등학교")
+    );
   }
 }

--- a/src/test/java/com/kindtalk/server/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kindtalk/server/member/service/MemberServiceTest.java
@@ -18,13 +18,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -39,24 +39,13 @@ public class MemberServiceTest {
   @Autowired
   SchoolRepository schoolRepository;
 
-  @Autowired
-  PasswordEncoder passwordEncoder;
-
-  private MemberJoinRequest member;
+  private Member member;
   private School school;
 
   @BeforeEach
   void setUp() {
     school = schoolRepository.save(new School("12345", "테스트 초등학교"));
-
-    member = new MemberJoinRequest(
-      "m1@email.com",
-      "11",
-      "박땡땡",
-      "박맘",
-      school.getCode(),
-      Role.TEACHER
-    );
+    member = memberRepository.save(new Member("m1@email.com", "1234", "회원1", "별명1", school, Role.TEACHER)); // default teacher
   }
 
   @AfterEach
@@ -66,28 +55,27 @@ public class MemberServiceTest {
 
   @Test
   void 회원가입_테스트() {
-    MemberResponse memberResponse = memberService.memberJoin(member);
+    // given
+    MemberJoinRequest request = new MemberJoinRequest("m2@email.com", "1234", "회원2", "별명2", "12345", Role.TEACHER);
 
-    assertThat(memberResponse.email()).isEqualTo("m1@email.com");
-    assertThat(memberResponse.userName()).isEqualTo("박땡땡");
-    assertThat(memberResponse.nickName()).isEqualTo("박맘");
-    assertThat(memberResponse.role()).isEqualTo(Role.TEACHER);
-  }
+    // when
+    MemberResponse memberResponse = memberService.memberJoin(request);
 
-  @Test
-  void 중복회원_테스트() {
-    memberRepository.save(new Member("m1@email.com", "11", "박땡땡", "박맘", school, Role.TEACHER));
-
-    DataAlreadyExistsException exception = assertThrows(DataAlreadyExistsException.class, () -> {
-      memberService.memberJoin(member);
-    });
-    assertThat(exception.getMessage()).isEqualTo("이미 존재하는 회원입니다.");
+    // then
+    assertAll(
+      () -> assertThat(memberResponse.email()).isEqualTo("m2@email.com"),
+      () -> assertThat(memberResponse.userName()).isEqualTo("회원2"),
+      () -> assertThat(memberResponse.nickName()).isEqualTo("별명2"),
+      () -> assertThat(memberResponse.schoolCode()).isEqualTo("12345"),
+      () -> assertThat(memberResponse.schoolName()).isEqualTo("테스트 초등학교"),
+      () -> assertThat(memberResponse.role()).isEqualTo(Role.TEACHER)
+    );
   }
 
   @Test
   void 선생님_학교_누락_시_회원가입_실패() {
     // given
-    MemberJoinRequest request = new MemberJoinRequest("m1@email.com", "11", "회원1", "별명1", null, Role.TEACHER);
+    MemberJoinRequest request = new MemberJoinRequest("m2@email.com", "1234", "회원2", "별명2", null, Role.TEACHER);
 
     // when & then
     BadRequestException exception = assertThrows(BadRequestException.class, () -> {
@@ -97,46 +85,66 @@ public class MemberServiceTest {
   }
 
   @Test
+  void 중복회원_테스트() {
+    // given
+    MemberJoinRequest request = new MemberJoinRequest("m1@email.com", "1234", "회원1", "별명1", "12345", Role.TEACHER);
+
+    // when & then
+    DataAlreadyExistsException exception = assertThrows(DataAlreadyExistsException.class, () -> {
+      memberService.memberJoin(request);
+    });
+    assertThat(exception.getMessage()).isEqualTo("이미 존재하는 회원입니다.");
+  }
+
+  @Test
   void 회원조회_테스트() {
-    String password = passwordEncoder.encode(member.password());
-    Member memberData = memberRepository.save(member.toEntity(password, school));
+    // given
+    MyUserDetails auth = new MyUserDetails(member);
 
-    MyUserDetails userDetails = new MyUserDetails(memberData);
+    // when
+    MemberResponse response = memberService.memberDetail(auth);
 
-    MemberResponse memberResponse = memberService.memberDetail(userDetails);
-
-    assertThat(memberResponse.email()).isEqualTo("m1@email.com");
-    assertThat(memberResponse.userName()).isEqualTo("박땡땡");
-    assertThat(memberResponse.nickName()).isEqualTo("박맘");
-    assertThat(memberResponse.role()).isEqualTo(Role.TEACHER);
+    // then
+    assertAll(
+      () -> assertThat(response.email()).isEqualTo("m1@email.com"),
+      () -> assertThat(response.userName()).isEqualTo("회원1"),
+      () -> assertThat(response.nickName()).isEqualTo("별명1"),
+      () -> assertThat(response.schoolCode()).isEqualTo("12345"),
+      () -> assertThat(response.schoolName()).isEqualTo("테스트 초등학교"),
+      () -> assertThat(response.role()).isEqualTo(Role.TEACHER)
+    );
   }
 
   @Test
   void 회원수정_테스트() {
-    String password = passwordEncoder.encode(member.password());
-    Member memberData = memberRepository.save(member.toEntity(password, school));
+    // given
+    MyUserDetails auth = new MyUserDetails(member);
+    MemberUpdateRequest request = new MemberUpdateRequest("개명함", "별명변경");
 
-    MyUserDetails userDetails = new MyUserDetails(memberData);
+    // when
+    MemberResponse response = memberService.memberUpdate(auth, request);
 
-    MemberUpdateRequest updateRequest = new MemberUpdateRequest("박둘", "박파더");
-    MemberResponse memberResponse = memberService.memberUpdate(userDetails, updateRequest);
-
-    assertThat(memberResponse.email()).isEqualTo("m1@email.com");
-    assertThat(memberResponse.userName()).isEqualTo("박둘");
-    assertThat(memberResponse.nickName()).isEqualTo("박파더");
-    assertThat(memberResponse.role()).isEqualTo(Role.TEACHER);
+    // then
+    assertAll(
+      () -> assertThat(response.email()).isEqualTo("m1@email.com"),
+      () -> assertThat(response.userName()).isEqualTo("개명함"),
+      () -> assertThat(response.nickName()).isEqualTo("별명변경"),
+      () -> assertThat(response.schoolCode()).isEqualTo("12345"),
+      () -> assertThat(response.schoolName()).isEqualTo("테스트 초등학교"),
+      () -> assertThat(response.role()).isEqualTo(Role.TEACHER)
+    );
   }
 
   @Test
   void 없는_회원_조회하기_테스트() {
-    String password = passwordEncoder.encode(member.password());
-    Member memberEntity = member.toEntity(password, school); // ???
+    // given
+    Member mock = mock(Member.class);
+    when(mock.getId()).thenReturn(100L);
+    MyUserDetails auth = new MyUserDetails(mock);
 
-    ReflectionTestUtils.setField(memberEntity, "id", 100L);
-    MyUserDetails userDetails = new MyUserDetails(memberEntity);
-
+    // when & then
     DataNotFoundException exception = assertThrows(DataNotFoundException.class, () -> {
-      memberService.memberDetail(userDetails);
+      memberService.memberDetail(auth);
     });
     assertThat(exception.getMessage()).isEqualTo("해당 회원이 존재하지 않습니다.");
   }
@@ -145,7 +153,6 @@ public class MemberServiceTest {
   void 선생님_학교_수정_테스트() {
     // given
     schoolRepository.save(new School("22222", "테스트2 초등학교"));
-    Member member = memberRepository.save(new Member("m1@email.com", "1234", "회원1", "별명1", school, Role.TEACHER));
 
     TeacherSchoolUpdateRequest request = new TeacherSchoolUpdateRequest("22222");
     MyUserDetails auth = new MyUserDetails(member);


### PR DESCRIPTION
## 수정 사항
Role.MEMBER를 Role.PARENT로 변경하였습니다.
MyUserDetails에 getMemberId() 메서드를 추가하여 회원 id를 바로 추출할 수 있도록 개선했습니다.

## 구현 내용
### 선생님 회원가입 로직
회원가입 시 Role.TEACHER을 받았을 때, 학교 코드를 필수로 입력받을 수 있도록 하였습니다.
schoolCode 누락시 `BadGatewayException` 예외를 호출하여 `BAD_REQUEST`를 반환합니다.

### 선생님 학교 수정
선생님이 자신의 소속 학교를 변경할 수 있도록 구현하였습니다.

### MemberResponse 학교 필드 추가
선생님 권한으로 조회 시 추가로 schoolCode, SchoolName 값을 반환합니다. 
만약 등록된 학교가 없으면 null을 반환합니다.

학부모 권한으로 조회 시 학교 정보는 null을 반환합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Teachers can now update and manage their school association through a dedicated API endpoint
  * Member profiles now display school information (code and name) for teachers
  * School association is required during teacher registration

* **Tests**
  * Expanded test coverage for member registration, profile updates, and school management functionality

* **Chores**
  * Updated member role naming conventions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->