### PR TITLE
Feat/child

### DIFF
--- a/src/main/java/com/kindtalk/server/child/controller/ChildController.java
+++ b/src/main/java/com/kindtalk/server/child/controller/ChildController.java
@@ -1,0 +1,60 @@
+package com.kindtalk.server.child.controller;
+
+import com.kindtalk.server.child.dto.ChildCreateRequest;
+import com.kindtalk.server.child.dto.ChildResponse;
+import com.kindtalk.server.child.dto.ChildUpdateRequest;
+import com.kindtalk.server.child.service.ChildService;
+import com.kindtalk.server.security.principal.MyUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/children")
+public class ChildController {
+
+  private final ChildService childService;
+
+  @PostMapping
+  public ResponseEntity<ChildResponse> create(
+    @AuthenticationPrincipal MyUserDetails auth,
+    @Valid @RequestBody ChildCreateRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+      .body(childService.create(auth, request));
+  }
+
+  @GetMapping
+  public ResponseEntity<List<ChildResponse>> findAll(
+    @AuthenticationPrincipal MyUserDetails auth) {
+    return ResponseEntity.ok(childService.findAll(auth));
+  }
+
+  @GetMapping("/{childId}")
+  public ResponseEntity<ChildResponse> detail(
+    @AuthenticationPrincipal MyUserDetails auth,
+    @PathVariable Long childId) {
+    return ResponseEntity.ok(childService.detail(childId, auth));
+  }
+
+  @PatchMapping("/{childId}")
+  public ResponseEntity<ChildResponse> update(
+    @AuthenticationPrincipal MyUserDetails auth,
+    @PathVariable Long childId,
+    @Valid @RequestBody ChildUpdateRequest request) {
+    return ResponseEntity.ok(childService.update(childId, auth, request));
+  }
+
+  @DeleteMapping("/{childId}")
+  public ResponseEntity<Void> delete(
+    @AuthenticationPrincipal MyUserDetails auth,
+    @PathVariable Long childId) {
+    childService.delete(childId, auth);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/kindtalk/server/child/domain/Child.java
+++ b/src/main/java/com/kindtalk/server/child/domain/Child.java
@@ -1,0 +1,48 @@
+package com.kindtalk.server.child.domain;
+
+import com.kindtalk.server.chatroom.domain.ChatRoom;
+import com.kindtalk.server.member.domain.Member;
+import com.kindtalk.server.school.domain.School;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Child {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String name;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent_id", nullable = false)
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "school_code", nullable = false)
+  private School school;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "chatroom_id")
+  private ChatRoom chatRoom;
+
+  public Child(String name, Member member, School school) {
+    this.name = name;
+    this.member = member;
+    this.school = school;
+  }
+
+  public void updateInfo(String name, School school) {
+    this.name = name;
+    this.school = school;
+  }
+
+  public void updateChatRoom(ChatRoom chatRoom) {
+    this.chatRoom = chatRoom;
+  }
+}

--- a/src/main/java/com/kindtalk/server/child/dto/ChildCreateRequest.java
+++ b/src/main/java/com/kindtalk/server/child/dto/ChildCreateRequest.java
@@ -1,0 +1,11 @@
+package com.kindtalk.server.child.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ChildCreateRequest(
+  @NotBlank
+  String name,
+
+  @NotBlank
+  String schoolCode) {
+}

--- a/src/main/java/com/kindtalk/server/child/dto/ChildResponse.java
+++ b/src/main/java/com/kindtalk/server/child/dto/ChildResponse.java
@@ -1,0 +1,21 @@
+package com.kindtalk.server.child.dto;
+
+import com.kindtalk.server.child.domain.Child;
+
+public record ChildResponse(
+  Long id,
+  Long parentId,
+  String name,
+  String schoolCode,
+  String schoolName) {
+
+  public static ChildResponse of(Child child) {
+    return new ChildResponse(
+      child.getId(),
+      child.getMember().getId(),
+      child.getName(),
+      child.getSchool().getCode(),
+      child.getSchool().getName()
+    );
+  }
+}

--- a/src/main/java/com/kindtalk/server/child/dto/ChildUpdateRequest.java
+++ b/src/main/java/com/kindtalk/server/child/dto/ChildUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.kindtalk.server.child.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ChildUpdateRequest(
+  @NotBlank
+  String name,
+
+  @NotBlank
+  String schoolCode) {
+}

--- a/src/main/java/com/kindtalk/server/child/repository/ChildRepository.java
+++ b/src/main/java/com/kindtalk/server/child/repository/ChildRepository.java
@@ -1,0 +1,14 @@
+package com.kindtalk.server.child.repository;
+
+import com.kindtalk.server.child.domain.Child;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChildRepository extends JpaRepository<Child, Long> {
+
+  List<Child> findAllByMemberId(Long id);
+
+  Optional<Child> findByIdAndMemberId(Long childId, Long parentId);
+}

--- a/src/main/java/com/kindtalk/server/child/repository/ChildRepository.java
+++ b/src/main/java/com/kindtalk/server/child/repository/ChildRepository.java
@@ -1,6 +1,7 @@
 package com.kindtalk.server.child.repository;
 
 import com.kindtalk.server.child.domain.Child;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.Optional;
 
 public interface ChildRepository extends JpaRepository<Child, Long> {
 
+  @EntityGraph(attributePaths = {"school"})
   List<Child> findAllByMemberId(Long id);
 
   Optional<Child> findByIdAndMemberId(Long childId, Long parentId);

--- a/src/main/java/com/kindtalk/server/child/service/ChildService.java
+++ b/src/main/java/com/kindtalk/server/child/service/ChildService.java
@@ -1,0 +1,84 @@
+package com.kindtalk.server.child.service;
+
+import com.kindtalk.server.child.domain.Child;
+import com.kindtalk.server.child.dto.ChildCreateRequest;
+import com.kindtalk.server.child.dto.ChildResponse;
+import com.kindtalk.server.child.dto.ChildUpdateRequest;
+import com.kindtalk.server.child.repository.ChildRepository;
+import com.kindtalk.server.exception.BusinessRuleException;
+import com.kindtalk.server.exception.DataNotFoundException;
+import com.kindtalk.server.member.domain.Member;
+import com.kindtalk.server.member.repository.MemberRepository;
+import com.kindtalk.server.member.role.Role;
+import com.kindtalk.server.school.domain.School;
+import com.kindtalk.server.school.repository.SchoolRepository;
+import com.kindtalk.server.security.principal.MyUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChildService {
+
+  private final ChildRepository childRepository;
+  private final MemberRepository memberRepository;
+  private final SchoolRepository schoolRepository;
+
+  @Transactional
+  public ChildResponse create(MyUserDetails auth, ChildCreateRequest request) {
+    Member member = findMember(auth.getMemberId());
+
+    if (member.getRole() != Role.PARENT) {
+      throw new BusinessRuleException("부모 권한을 가진 사용자만 자녀를 등록할 수 있습니다.");
+    }
+
+    School school = findSchool(request.schoolCode());
+    Child child = childRepository.save(new Child(request.name(), member, school));
+    return ChildResponse.of(child);
+  }
+
+  private Member findMember(Long memberId) {
+    return memberRepository.findById(memberId)
+      .orElseThrow(() -> new DataNotFoundException("해당 회원이 존재하지 않습니다."));
+  }
+
+  private School findSchool(String schoolCode) {
+    return schoolRepository.findById(schoolCode)
+      .orElseThrow(() -> new DataNotFoundException("해당 학교가 존재하지 않습니다."));
+  }
+
+  @Transactional(readOnly = true)
+  public List<ChildResponse> findAll(MyUserDetails auth) {
+    Member member = findMember(auth.getMemberId());
+    List<Child> children = childRepository.findAllByMemberId(member.getId());
+    return children.stream().map(ChildResponse::of).toList();
+  }
+
+  @Transactional(readOnly = true)
+  public ChildResponse detail(Long childId, MyUserDetails auth) {
+    Child child = findChild(childId, auth.getMemberId());
+    return ChildResponse.of(child);
+  }
+
+  private Child findChild(Long childId, Long parentId) {
+    return childRepository.findByIdAndMemberId(childId, parentId)
+      .orElseThrow(() -> new DataNotFoundException("해당 부모의 자녀가 존재하지 않습니다."));
+  }
+
+  @Transactional
+  public ChildResponse update(Long childId, MyUserDetails auth, ChildUpdateRequest request) {
+    Child child = findChild(childId, auth.getMemberId());
+    School school = findSchool(request.schoolCode());
+    child.updateInfo(request.name(), school);
+    return ChildResponse.of(child);
+  }
+
+  @Transactional
+  public void delete(Long childId, MyUserDetails auth) {
+    Child child = findChild(childId, auth.getMemberId());
+    childRepository.delete(child);
+  }
+}

--- a/src/main/java/com/kindtalk/server/child/service/ChildService.java
+++ b/src/main/java/com/kindtalk/server/child/service/ChildService.java
@@ -52,8 +52,7 @@ public class ChildService {
 
   @Transactional(readOnly = true)
   public List<ChildResponse> findAll(MyUserDetails auth) {
-    Member member = findMember(auth.getMemberId());
-    List<Child> children = childRepository.findAllByMemberId(member.getId());
+    List<Child> children = childRepository.findAllByMemberId(auth.getMemberId());
     return children.stream().map(ChildResponse::of).toList();
   }
 

--- a/src/test/java/com/kindtalk/server/child/service/ChildServiceTest.java
+++ b/src/test/java/com/kindtalk/server/child/service/ChildServiceTest.java
@@ -1,0 +1,180 @@
+package com.kindtalk.server.child.service;
+
+import com.kindtalk.server.child.domain.Child;
+import com.kindtalk.server.child.dto.ChildCreateRequest;
+import com.kindtalk.server.child.dto.ChildResponse;
+import com.kindtalk.server.child.dto.ChildUpdateRequest;
+import com.kindtalk.server.child.repository.ChildRepository;
+import com.kindtalk.server.exception.BusinessRuleException;
+import com.kindtalk.server.exception.DataNotFoundException;
+import com.kindtalk.server.member.domain.Member;
+import com.kindtalk.server.member.repository.MemberRepository;
+import com.kindtalk.server.member.role.Role;
+import com.kindtalk.server.school.domain.School;
+import com.kindtalk.server.school.repository.SchoolRepository;
+import com.kindtalk.server.security.principal.MyUserDetails;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class ChildServiceTest {
+
+  @Autowired
+  ChildService childService;
+
+  @Autowired
+  ChildRepository childrepository;
+
+  @Autowired
+  MemberRepository memberRepository;
+
+  @Autowired
+  SchoolRepository schoolRepository;
+
+  private Member member;
+  private School school;
+  private MyUserDetails auth;
+
+  @BeforeEach
+  void setUp() {
+    school = schoolRepository.save(new School("12345", "테스트 초등학교"));
+    member = memberRepository.save(new Member("m1@email.com", "1234", "회원1", "별명1", null, Role.PARENT));
+    auth = new MyUserDetails(member);
+  }
+
+  @AfterEach
+  void delete() {
+    childrepository.deleteAll();
+    memberRepository.deleteAll();
+    schoolRepository.deleteAll();
+  }
+
+  @Test
+  void 자녀_등록_테스트() {
+    // given
+    ChildCreateRequest request = new ChildCreateRequest("자녀1", "12345");
+
+    // when
+    ChildResponse response = childService.create(auth, request);
+
+    // then
+    assertAll(
+      () -> assertThat(response.name()).isEqualTo("자녀1"),
+      () -> assertThat(response.schoolCode()).isEqualTo("12345"),
+      () -> assertThat(response.schoolName()).isEqualTo("테스트 초등학교")
+    );
+  }
+
+  @Test
+  void 부모_권한이_아니면_자녀_등록_실패() {
+    // given
+    Member member1 = memberRepository.save(new Member("m2@email.com", "1234", "회원2", "별명2", school, Role.TEACHER));
+    ChildCreateRequest request = new ChildCreateRequest("자녀1", "12345");
+    MyUserDetails auth1 = new MyUserDetails(member1);
+
+    // then
+    BusinessRuleException exception = assertThrows(BusinessRuleException.class, () -> {
+      childService.create(auth1, request);
+    });
+    assertThat(exception.getMessage()).isEqualTo("부모 권한을 가진 사용자만 자녀를 등록할 수 있습니다.");
+  }
+
+  @Test
+  void 자녀_목록_조회_테스트() {
+    // given
+    School school1 = schoolRepository.save(new School("22222", "테스트2 초등학교"));
+
+    Child child1 = childrepository.save(new Child("자녀3", member, school));
+    Child child2 = childrepository.save(new Child("자녀4", member, school1)); // 다른 학교 등록
+
+    // when
+    List<ChildResponse> children = childService.findAll(auth);
+
+    // then
+    assertThat(children)
+      .isNotEmpty()
+      .hasSize(2)
+      .extracting(
+        ChildResponse::id,
+        ChildResponse::parentId,
+        ChildResponse::name,
+        ChildResponse::schoolName)
+      .containsExactlyInAnyOrder(
+        tuple(child1.getId(), auth.getMemberId(), "자녀3", "테스트 초등학교"),
+        tuple(child2.getId(), auth.getMemberId(), "자녀4", "테스트2 초등학교")
+      );
+  }
+
+  @Test
+  void 자녀_상세_조회_테스트() {
+    // given
+    Child child = childrepository.save(new Child("자녀5", member, school));
+
+    // when
+    ChildResponse response1 = childService.detail(child.getId(), auth);
+
+    // then
+    assertAll(
+      () -> assertThat(response1.parentId()).isEqualTo(auth.getMemberId()),
+      () -> assertThat(response1.name()).isEqualTo("자녀5"),
+      () -> assertThat(response1.schoolCode()).isEqualTo("12345"),
+      () -> assertThat(response1.schoolName()).isEqualTo("테스트 초등학교")
+    );
+  }
+
+  @Test
+  void 존재하지_않는_자녀_조회_시_실패() {
+    // when & then
+    DataNotFoundException exception = assertThrows(DataNotFoundException.class, () -> {
+      childService.detail(100L, auth);
+    });
+    assertThat(exception.getMessage()).isEqualTo("해당 부모의 자녀가 존재하지 않습니다.");
+  }
+
+  @Test
+  void 자녀_정보_수정_테스트() {
+    // given
+    schoolRepository.save(new School("33333", "테스트3 초등학교"));
+    Child child = childrepository.save(new Child("자녀6", member, school));
+
+    ChildUpdateRequest request = new ChildUpdateRequest("개명함", "33333");
+
+    // when
+    ChildResponse response1 = childService.update(child.getId(), auth, request);
+
+    // then
+    assertAll(
+      () -> assertThat(response1.parentId()).isEqualTo(auth.getMemberId()),
+      () -> assertThat(response1.name()).isEqualTo("개명함"),
+      () -> assertThat(response1.schoolCode()).isEqualTo("33333"),
+      () -> assertThat(response1.schoolName()).isEqualTo("테스트3 초등학교")
+    );
+  }
+
+  @Test
+  void 자녀_삭제_테스트() {
+    // given
+    Child child = childrepository.save(new Child("자녀6", member, school));
+
+    // when
+    childService.delete(child.getId(), auth);
+
+    // then
+    DataNotFoundException exception = assertThrows(DataNotFoundException.class, () -> {
+      childService.detail(child.getId(), auth);
+    });
+    assertThat(exception.getMessage()).isEqualTo("해당 부모의 자녀가 존재하지 않습니다.");
+  }
+}

--- a/src/test/java/com/kindtalk/server/child/service/ChildServiceTest.java
+++ b/src/test/java/com/kindtalk/server/child/service/ChildServiceTest.java
@@ -35,7 +35,7 @@ public class ChildServiceTest {
   ChildService childService;
 
   @Autowired
-  ChildRepository childrepository;
+  ChildRepository childRepository;
 
   @Autowired
   MemberRepository memberRepository;
@@ -56,7 +56,7 @@ public class ChildServiceTest {
 
   @AfterEach
   void delete() {
-    childrepository.deleteAll();
+    childRepository.deleteAll();
     memberRepository.deleteAll();
     schoolRepository.deleteAll();
   }
@@ -96,8 +96,8 @@ public class ChildServiceTest {
     // given
     School school1 = schoolRepository.save(new School("22222", "테스트2 초등학교"));
 
-    Child child1 = childrepository.save(new Child("자녀3", member, school));
-    Child child2 = childrepository.save(new Child("자녀4", member, school1)); // 다른 학교 등록
+    Child child1 = childRepository.save(new Child("자녀3", member, school));
+    Child child2 = childRepository.save(new Child("자녀4", member, school1)); // 다른 학교 등록
 
     // when
     List<ChildResponse> children = childService.findAll(auth);
@@ -120,7 +120,7 @@ public class ChildServiceTest {
   @Test
   void 자녀_상세_조회_테스트() {
     // given
-    Child child = childrepository.save(new Child("자녀5", member, school));
+    Child child = childRepository.save(new Child("자녀5", member, school));
 
     // when
     ChildResponse response1 = childService.detail(child.getId(), auth);
@@ -147,7 +147,7 @@ public class ChildServiceTest {
   void 자녀_정보_수정_테스트() {
     // given
     schoolRepository.save(new School("33333", "테스트3 초등학교"));
-    Child child = childrepository.save(new Child("자녀6", member, school));
+    Child child = childRepository.save(new Child("자녀6", member, school));
 
     ChildUpdateRequest request = new ChildUpdateRequest("개명함", "33333");
 
@@ -166,7 +166,7 @@ public class ChildServiceTest {
   @Test
   void 자녀_삭제_테스트() {
     // given
-    Child child = childrepository.save(new Child("자녀6", member, school));
+    Child child = childRepository.save(new Child("자녀6", member, school));
 
     // when
     childService.delete(child.getId(), auth);


### PR DESCRIPTION
close #13 

## 구현 사항

### 자녀 등록
자녀의 이름, 학교 코드를 받고 등록합니다.
사용자의 권한이 PARENT인 경우에만 등록할 수 있도록 하였습니다.

### 자녀 목록 조회
현재 로그인한 부모 사용자의 자녀 목록을 불러옵니다.

### 자녀 상세 조회
Pathvariable로 받은 childId를 통해 자녀의 상세 정보를 조회할 수 있습니다.
로그인한 부모 사용자의 자녀만 조회할 수 있도록 하였습니다. 

### 자녀 정보 수정
자녀의 이름과 소속 학교를 수정할 수 있습니다. 
상세 조회와 동일하게 본인의 자녀인 경우에만 수정할 수 있도록 하였습니다.

### 자녀 삭제
더 이상 관리하지 않는 자녀를 삭제할 수 있습니다.
삭제 시 http status는 204 No Content로 설정하였습니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Child profile management for parents: create, list, view, update, and delete child records.
  * Manage child attributes including name and school assignment; individual child detail view available.

* **Tests**
  * Added comprehensive test coverage for child management flows and authorization validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->