### PR TITLE
feat(topic): implement topic's CRUD methods

### DIFF
--- a/src/main/java/com/kindtalk/server/message/document/Message.java
+++ b/src/main/java/com/kindtalk/server/message/document/Message.java
@@ -18,11 +18,22 @@ public class Message {
   private Long senderId;
   private String content;
   private Instant sendAt;
+  private Long topicId;
+  private Long parentId;
 
   public Message(Long roomId, Long senderId, String content, Instant sendAt) {
     this.roomId = roomId;
     this.senderId = senderId;
     this.content = content;
     this.sendAt = sendAt;
+  }
+
+  public Message(Long roomId, Long senderId, String content, Instant sendAt, Long parentId) {
+    this(roomId, senderId, content, sendAt);
+    this.parentId = parentId;
+  }
+
+  public void setTopicId(Long topicId) {
+    this.topicId = topicId;
   }
 }

--- a/src/main/java/com/kindtalk/server/message/repository/MessageRepository.java
+++ b/src/main/java/com/kindtalk/server/message/repository/MessageRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 public interface MessageRepository extends MongoRepository<Message, String> {
 
   List<Message> findAllByRoomIdOrderBySendAtAsc(Long roomId);
+
+  List<Message> findAllByTopicIdOrderBySendAtDesc(Long topicId);
 }

--- a/src/main/java/com/kindtalk/server/message/service/MessageService.java
+++ b/src/main/java/com/kindtalk/server/message/service/MessageService.java
@@ -28,4 +28,10 @@ public class MessageService {
       .map(MessageResponse::of)
       .toList();
   }
+
+  public List<MessageResponse> getHistoryOfTopic(Long topicId) {
+    return messageRepository.findAllByTopicIdOrderBySendAtDesc(topicId).stream()
+      .map(MessageResponse::of)
+      .toList();
+  }
 }

--- a/src/main/java/com/kindtalk/server/topic/controller/TopicController.java
+++ b/src/main/java/com/kindtalk/server/topic/controller/TopicController.java
@@ -7,7 +7,6 @@ import com.kindtalk.server.topic.dto.TopicResponse;
 import com.kindtalk.server.topic.service.TopicService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/kindtalk/server/topic/controller/TopicController.java
+++ b/src/main/java/com/kindtalk/server/topic/controller/TopicController.java
@@ -1,0 +1,54 @@
+package com.kindtalk.server.topic.controller;
+
+import com.kindtalk.server.message.dto.MessageResponse;
+import com.kindtalk.server.message.service.MessageService;
+import com.kindtalk.server.topic.dto.TopicRequest;
+import com.kindtalk.server.topic.dto.TopicResponse;
+import com.kindtalk.server.topic.service.TopicService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/topics")
+@RequiredArgsConstructor
+public class TopicController {
+
+  private final TopicService topicService;
+  private final MessageService messageService;
+
+  @GetMapping("/{id}")
+  public ResponseEntity<TopicResponse> getTopic(@PathVariable Long id) {
+    return ResponseEntity.ok(topicService.getTopic(id));
+  }
+
+  @GetMapping("/chatroom/{id}")
+  public ResponseEntity<List<TopicResponse>> getTopics(
+    @PathVariable("id") Long chatRoomId
+  ) {
+    return ResponseEntity.ok(topicService.getTopics(chatRoomId));
+  }
+
+  @PostMapping("/chatroom/{id}")
+  public ResponseEntity<TopicResponse> createTopics(
+    @PathVariable("id") Long chatRoomId,
+    @RequestBody TopicRequest topicRequest) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+      .body(topicService.createTopic(chatRoomId, topicRequest));
+  }
+
+  @GetMapping("/{id}/messages")
+  public ResponseEntity<List<MessageResponse>> getHistoryOfTopic(
+    @PathVariable("id") Long topicId
+  ) {
+    return ResponseEntity.ok(messageService.getHistoryOfTopic(topicId));
+  }
+}

--- a/src/main/java/com/kindtalk/server/topic/domain/Topic.java
+++ b/src/main/java/com/kindtalk/server/topic/domain/Topic.java
@@ -1,0 +1,39 @@
+package com.kindtalk.server.topic.domain;
+
+import com.kindtalk.server.chatroom.domain.ChatRoom;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Topic {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true)
+  private String title;
+
+  private LocalDateTime archivedAt;
+
+  @ManyToOne
+  @JoinColumn(name = "chatroom_id")
+  private ChatRoom chatRoom;
+
+  public Topic(String title, ChatRoom chatRoom) {
+    this.title = title;
+    this.chatRoom = chatRoom;
+    archivedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/com/kindtalk/server/topic/dto/TopicRequest.java
+++ b/src/main/java/com/kindtalk/server/topic/dto/TopicRequest.java
@@ -1,0 +1,10 @@
+package com.kindtalk.server.topic.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TopicRequest(
+  @NotBlank(message = "스레드의 제목을 입력해주세요.")
+  String title
+) {
+
+}

--- a/src/main/java/com/kindtalk/server/topic/dto/TopicResponse.java
+++ b/src/main/java/com/kindtalk/server/topic/dto/TopicResponse.java
@@ -1,0 +1,24 @@
+package com.kindtalk.server.topic.dto;
+
+import com.kindtalk.server.topic.domain.Topic;
+import java.time.LocalDateTime;
+
+public record TopicResponse(
+  Long id,
+
+  String title,
+
+  LocalDateTime archivedAt,
+
+  Long chatRoomId
+) {
+
+  public static TopicResponse of(Topic topic) {
+    return new TopicResponse(
+      topic.getId(),
+      topic.getTitle(),
+      topic.getArchivedAt(),
+      topic.getChatRoom().getId()
+    );
+  }
+}

--- a/src/main/java/com/kindtalk/server/topic/repository/TopicRepository.java
+++ b/src/main/java/com/kindtalk/server/topic/repository/TopicRepository.java
@@ -2,6 +2,7 @@ package com.kindtalk.server.topic.repository;
 
 import com.kindtalk.server.chatroom.domain.ChatRoom;
 import com.kindtalk.server.topic.domain.Topic;
+import java.util.List;
 import java.util.Optional;
 import java.util.jar.JarFile;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +10,5 @@ import org.springframework.data.mongodb.core.aggregation.SelectionOperators.Top;
 
 public interface TopicRepository extends JpaRepository<Topic, Long> {
 
-  Optional<Topic> findByChatRoom(ChatRoom chatRoom);
+  List<Topic> findAllByChatRoom(ChatRoom chatRoom);
 }

--- a/src/main/java/com/kindtalk/server/topic/repository/TopicRepository.java
+++ b/src/main/java/com/kindtalk/server/topic/repository/TopicRepository.java
@@ -1,0 +1,13 @@
+package com.kindtalk.server.topic.repository;
+
+import com.kindtalk.server.chatroom.domain.ChatRoom;
+import com.kindtalk.server.topic.domain.Topic;
+import java.util.Optional;
+import java.util.jar.JarFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.mongodb.core.aggregation.SelectionOperators.Top;
+
+public interface TopicRepository extends JpaRepository<Topic, Long> {
+
+  Optional<Topic> findByChatRoom(ChatRoom chatRoom);
+}

--- a/src/main/java/com/kindtalk/server/topic/service/TopicService.java
+++ b/src/main/java/com/kindtalk/server/topic/service/TopicService.java
@@ -23,7 +23,7 @@ public class TopicService {
   public List<TopicResponse> getTopics(Long chatRoomId) {
     ChatRoom chatRoom = getChatRoom(chatRoomId);
 
-    return topicRepository.findByChatRoom(chatRoom).stream()
+    return topicRepository.findAllByChatRoom(chatRoom).stream()
       .map(TopicResponse::of)
       .toList();
   }

--- a/src/main/java/com/kindtalk/server/topic/service/TopicService.java
+++ b/src/main/java/com/kindtalk/server/topic/service/TopicService.java
@@ -1,0 +1,53 @@
+package com.kindtalk.server.topic.service;
+
+import com.kindtalk.server.chatroom.domain.ChatRoom;
+import com.kindtalk.server.chatroom.repository.ChatRoomRepository;
+import com.kindtalk.server.exception.DataNotFoundException;
+import com.kindtalk.server.topic.domain.Topic;
+import com.kindtalk.server.topic.dto.TopicRequest;
+import com.kindtalk.server.topic.dto.TopicResponse;
+import com.kindtalk.server.topic.repository.TopicRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TopicService {
+
+  private final TopicRepository topicRepository;
+  private final ChatRoomRepository chatRoomRepository;
+
+  @Transactional(readOnly = true)
+  public List<TopicResponse> getTopics(Long chatRoomId) {
+    ChatRoom chatRoom = getChatRoom(chatRoomId);
+
+    return topicRepository.findByChatRoom(chatRoom).stream()
+      .map(TopicResponse::of)
+      .toList();
+  }
+
+  @Transactional
+  public TopicResponse createTopic(Long chatRoomId, TopicRequest topicRequest) {
+    ChatRoom chatRoom = getChatRoom(chatRoomId);
+
+    Topic topic = new Topic(topicRequest.title(), chatRoom);
+
+    return TopicResponse.of(topicRepository.save(topic));
+  }
+
+  @Transactional(readOnly = true)
+  public TopicResponse getTopic(Long id) {
+    return TopicResponse.of(
+      topicRepository.findById(id)
+        .orElseThrow(() -> new DataNotFoundException("존재하지 않는 스레드입니다."))
+    );
+  }
+
+  private ChatRoom getChatRoom(Long chatRoomId) {
+    return chatRoomRepository.findById(chatRoomId).orElseThrow(
+      () -> new DataNotFoundException("존재하지 않는 채팅방입니다.")
+    );
+  }
+}


### PR DESCRIPTION
close #15 

## 구현 내용

채팅 스레드와 관련된 CRUD 메서드를 만들었습니다.

우선 스레드 자체 CRUD만 만들었으며 다음 주 중으로 연관관계를 다시 매핑하고 메시지를 스레드에 추가하는 로직도 구현할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Topic (thread) management: create, list, and view topics within chat rooms for better organization
  * Topic message history: retrieve messages for a topic, sorted by most recent
  * Threading support: messages can be associated with a topic and reference a parent message to enable replies and nested conversations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->