### PR TITLE
Feat/messages enhancement

### DIFF
--- a/src/main/java/com/kindtalk/server/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/kindtalk/server/chatroom/controller/ChatRoomController.java
@@ -17,10 +17,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/chatroom")
+@RequestMapping("/api/chatrooms")
 @RequiredArgsConstructor
 public class ChatRoomController {
 
@@ -47,7 +48,10 @@ public class ChatRoomController {
   }
 
   @GetMapping("/{roomId}/messages")
-  public ResponseEntity<List<MessageResponse>> getHistory(@PathVariable Long roomId) {
-    return ResponseEntity.ok(messageService.getHistory(roomId));
+  public ResponseEntity<List<MessageResponse>> getHistory(
+    @PathVariable Long roomId,
+    @RequestParam(defaultValue = "0") int page,
+    @RequestParam(defaultValue = "10") int size) {
+    return ResponseEntity.ok(messageService.getHistory(roomId, page, size));
   }
 }

--- a/src/main/java/com/kindtalk/server/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/kindtalk/server/chatroom/controller/ChatRoomController.java
@@ -7,8 +7,9 @@ import com.kindtalk.server.chatroom.service.ChatRoomService;
 import com.kindtalk.server.message.dto.MessageResponse;
 import com.kindtalk.server.message.service.MessageService;
 import jakarta.validation.Valid;
-import java.util.List;
+import java.time.Instant;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -48,10 +49,10 @@ public class ChatRoomController {
   }
 
   @GetMapping("/{roomId}/messages")
-  public ResponseEntity<List<MessageResponse>> getHistory(
+  public ResponseEntity<Slice<MessageResponse>> getHistory(
     @PathVariable Long roomId,
-    @RequestParam(defaultValue = "0") int page,
+    @RequestParam(required = false) Instant cursor,
     @RequestParam(defaultValue = "10") int size) {
-    return ResponseEntity.ok(messageService.getHistory(roomId, page, size));
+    return ResponseEntity.ok(messageService.getHistory(roomId, cursor, size));
   }
 }

--- a/src/main/java/com/kindtalk/server/message/document/Message.java
+++ b/src/main/java/com/kindtalk/server/message/document/Message.java
@@ -11,7 +11,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "chat_message")
 @CompoundIndexes({
   @CompoundIndex(name = "idx_room_sendat_desc", def = "{'roomId': 1, 'sendAt': -1}"),
-  @CompoundIndex(name = "idx_topic_sendat_asc", def = "{'topicId': 1, 'sendAt': 1, sparse = true")
+  @CompoundIndex(name = "idx_topic_sendat_asc", def = "{'topicId': 1, 'sendAt': 1, sparse = true}")
 })
 public class Message {
 

--- a/src/main/java/com/kindtalk/server/message/document/Message.java
+++ b/src/main/java/com/kindtalk/server/message/document/Message.java
@@ -11,7 +11,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "chat_message")
 @CompoundIndexes({
   @CompoundIndex(name = "idx_room_sendat_desc", def = "{'roomId': 1, 'sendAt': -1}"),
-  @CompoundIndex(name = "idx_topic_sendat_asc", def = "{'topicId: 1, 'sendAt': 1, sparse = true")
+  @CompoundIndex(name = "idx_topic_sendat_asc", def = "{'topicId': 1, 'sendAt': 1, sparse = true")
 })
 public class Message {
 

--- a/src/main/java/com/kindtalk/server/message/document/Message.java
+++ b/src/main/java/com/kindtalk/server/message/document/Message.java
@@ -3,17 +3,21 @@ package com.kindtalk.server.message.document;
 import java.time.Instant;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
 @Document(collection = "chat_message")
+@CompoundIndexes({
+  @CompoundIndex(name = "idx_room_sendat_desc", def = "{'roomId': 1, 'sendAt': -1}"),
+  @CompoundIndex(name = "idx_topic_sendat_asc", def = "{'topicId: 1, 'sendAt': 1, sparse = true")
+})
 public class Message {
 
   @Id
   private String id;
 
-  @Indexed
   private Long roomId;
   private Long senderId;
   private String content;

--- a/src/main/java/com/kindtalk/server/message/document/Message.java
+++ b/src/main/java/com/kindtalk/server/message/document/Message.java
@@ -11,7 +11,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "chat_message")
 @CompoundIndexes({
   @CompoundIndex(name = "idx_room_sendat_desc", def = "{'roomId': 1, 'sendAt': -1}"),
-  @CompoundIndex(name = "idx_topic_sendat_asc", def = "{'topicId': 1, 'sendAt': 1, sparse = true}")
+  @CompoundIndex(name = "idx_topic_sendat_asc", def = "{'topicId': 1, 'sendAt': 1}", sparse = true)
 })
 public class Message {
 

--- a/src/main/java/com/kindtalk/server/message/repository/MessageRepository.java
+++ b/src/main/java/com/kindtalk/server/message/repository/MessageRepository.java
@@ -1,12 +1,20 @@
 package com.kindtalk.server.message.repository;
 
 import com.kindtalk.server.message.document.Message;
-import java.util.List;
+import java.time.Instant;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface MessageRepository extends MongoRepository<Message, String> {
 
-  List<Message> findAllByRoomIdOrderBySendAtAsc(Long roomId);
+  Slice<Message> findByTopicIdAndSendAtLessThanOrderBySendAtAsc(
+    Long topicId,
+    Instant sendAt,
+    Pageable pageable);
 
-  List<Message> findAllByTopicIdOrderBySendAtDesc(Long topicId);
+  Slice<Message> findByRoomIdAndSendAtLessThanOrderBySendAtDesc(
+    Long roomId,
+    Instant sendAt,
+    Pageable pageable);
 }

--- a/src/main/java/com/kindtalk/server/message/service/MessageService.java
+++ b/src/main/java/com/kindtalk/server/message/service/MessageService.java
@@ -5,8 +5,10 @@ import com.kindtalk.server.message.dto.MessageRequest;
 import com.kindtalk.server.message.dto.MessageResponse;
 import com.kindtalk.server.message.repository.MessageRepository;
 import java.time.Instant;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,15 +25,23 @@ public class MessageService {
     return MessageResponse.of(message);
   }
 
-  public List<MessageResponse> getHistory(Long roomId) {
-    return messageRepository.findAllByRoomIdOrderBySendAtAsc(roomId).stream()
-      .map(MessageResponse::of)
-      .toList();
+  public Slice<MessageResponse> getHistory(Long roomId, Instant cursor, int size) {
+    Pageable pageable = PageRequest.of(0, size);
+
+    return messageRepository.findByRoomIdAndSendAtLessThanOrderBySendAtDesc(
+        roomId,
+        cursor,
+        pageable)
+      .map(MessageResponse::of);
   }
 
-  public List<MessageResponse> getHistoryOfTopic(Long topicId) {
-    return messageRepository.findAllByTopicIdOrderBySendAtDesc(topicId).stream()
-      .map(MessageResponse::of)
-      .toList();
+  public Slice<MessageResponse> getHistoryOfTopic(Long topicId, Instant cursor, int size) {
+    Pageable pageable = PageRequest.of(0, size);
+
+    return messageRepository.findByTopicIdAndSendAtLessThanOrderBySendAtAsc(
+        topicId,
+        cursor,
+        pageable)
+      .map(MessageResponse::of);
   }
 }

--- a/src/main/java/com/kindtalk/server/message/service/MessageService.java
+++ b/src/main/java/com/kindtalk/server/message/service/MessageService.java
@@ -28,6 +28,10 @@ public class MessageService {
   public Slice<MessageResponse> getHistory(Long roomId, Instant cursor, int size) {
     Pageable pageable = PageRequest.of(0, size);
 
+    if (cursor == null) {
+      cursor = Instant.now();
+    }
+
     return messageRepository.findByRoomIdAndSendAtLessThanOrderBySendAtDesc(
         roomId,
         cursor,
@@ -37,6 +41,10 @@ public class MessageService {
 
   public Slice<MessageResponse> getHistoryOfTopic(Long topicId, Instant cursor, int size) {
     Pageable pageable = PageRequest.of(0, size);
+
+    if (cursor == null) {
+      cursor = Instant.now();
+    }
 
     return messageRepository.findByTopicIdAndSendAtLessThanOrderBySendAtAsc(
         topicId,

--- a/src/main/java/com/kindtalk/server/topic/controller/TopicController.java
+++ b/src/main/java/com/kindtalk/server/topic/controller/TopicController.java
@@ -5,8 +5,10 @@ import com.kindtalk.server.message.service.MessageService;
 import com.kindtalk.server.topic.dto.TopicRequest;
 import com.kindtalk.server.topic.dto.TopicResponse;
 import com.kindtalk.server.topic.service.TopicService;
+import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -45,9 +48,10 @@ public class TopicController {
   }
 
   @GetMapping("/{id}/messages")
-  public ResponseEntity<List<MessageResponse>> getHistoryOfTopic(
-    @PathVariable("id") Long topicId
-  ) {
-    return ResponseEntity.ok(messageService.getHistoryOfTopic(topicId));
+  public ResponseEntity<Slice<MessageResponse>> getHistoryOfTopic(
+    @PathVariable("id") Long topicId,
+    @RequestParam(required = false) Instant cursor,
+    @RequestParam(defaultValue = "20") int size) {
+    return ResponseEntity.ok(messageService.getHistoryOfTopic(topicId, cursor, size));
   }
 }

--- a/src/main/java/com/kindtalk/server/topic/dto/TopicResponse.java
+++ b/src/main/java/com/kindtalk/server/topic/dto/TopicResponse.java
@@ -10,7 +10,7 @@ public record TopicResponse(
 
   LocalDateTime archivedAt,
 
-  Long chatRoomId
+  Long chatroomId
 ) {
 
   public static TopicResponse of(Topic topic) {

--- a/src/main/java/com/kindtalk/server/topic/dto/TopicResponse.java
+++ b/src/main/java/com/kindtalk/server/topic/dto/TopicResponse.java
@@ -10,7 +10,7 @@ public record TopicResponse(
 
   LocalDateTime archivedAt,
 
-  Long chatroomId
+  Long chatRoomId
 ) {
 
   public static TopicResponse of(Topic topic) {


### PR DESCRIPTION
close #17 

## 구현 내용
- chatroom API의 endpoint를 REST API 규칙에 맞춰 수정했습니다(chatroom -> chatrooms)
- Slice 인터페이스와 cursor를 이용해 무한 스크롤을 구현했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Message history retrieval now supports cursor-based pagination with fully customizable page sizes for both chat room and topic messages

* **Refactor**
  * Updated API endpoint base path from `/api/chatroom` to `/api/chatrooms`
  * Refined database indexing strategy with new compound indexes for message queries
  * Updated response field naming conventions for API consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->