### PR TITLE
Feat/session

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/kindtalk/server/config/SecurityFilterConfig.java
+++ b/src/main/java/com/kindtalk/server/config/SecurityFilterConfig.java
@@ -1,5 +1,6 @@
 package com.kindtalk.server.config;
 
+import com.kindtalk.server.security.handler.CustomAuthenticationEntryPoint;
 import com.kindtalk.server.security.handler.CustomLoginFailureHandler;
 import com.kindtalk.server.security.handler.CustomLoginSuccessHandler;
 import com.kindtalk.server.security.handler.CustomLogoutSuccessHandler;
@@ -22,6 +23,7 @@ public class SecurityFilterConfig {
   private final CustomLoginSuccessHandler customLoginSuccessHandler;
   private final CustomLoginFailureHandler customLoginFailureHandler;
   private final CustomLogoutSuccessHandler customLogoutSuccessHandler;
+  private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -44,11 +46,14 @@ public class SecurityFilterConfig {
         .successHandler(customLoginSuccessHandler)
         .failureHandler(customLoginFailureHandler)
       )
+      .exceptionHandling(exception -> exception
+        .authenticationEntryPoint((authenticationEntryPoint))
+      )
       .logout(logout -> logout
         .logoutUrl("/api/member/logout")
         .logoutSuccessHandler(customLogoutSuccessHandler)
         .invalidateHttpSession(true)
-        .deleteCookies("JSESSIONID")
+        .deleteCookies("KIND_SESSION")
       );
 
     return http.build();

--- a/src/main/java/com/kindtalk/server/config/SessionConfig.java
+++ b/src/main/java/com/kindtalk/server/config/SessionConfig.java
@@ -14,7 +14,10 @@ import java.util.Map;
 import java.util.function.BiFunction;
 
 @Configuration
-@EnableRedisHttpSession(redisNamespace = "kindtalk:session")
+@EnableRedisHttpSession(
+  redisNamespace = "kindtalk:session",
+  maxInactiveIntervalInSeconds = 604800
+)
 public class SessionConfig {
 
   @Bean

--- a/src/main/java/com/kindtalk/server/config/SessionConfig.java
+++ b/src/main/java/com/kindtalk/server/config/SessionConfig.java
@@ -1,0 +1,59 @@
+package com.kindtalk.server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.MapSession;
+import org.springframework.session.config.SessionRepositoryCustomizer;
+import org.springframework.session.data.redis.RedisSessionMapper;
+import org.springframework.session.data.redis.RedisSessionRepository;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.session.web.http.CookieSerializer;
+import org.springframework.session.web.http.DefaultCookieSerializer;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+
+@Configuration
+@EnableRedisHttpSession(redisNamespace = "kindtalk:session")
+public class SessionConfig {
+
+  @Bean
+  SessionRepositoryCustomizer<RedisSessionRepository> repositorySessionRepositoryCustomizer() {
+    return (redisSessionRepository) -> redisSessionRepository
+      .setRedisSessionMapper(new SafeRedisSessionMapper(redisSessionRepository));
+  }
+
+  static class SafeRedisSessionMapper implements BiFunction<String, Map<String, Object>, MapSession> {
+
+    private final RedisSessionMapper delegate = new RedisSessionMapper();
+    private final RedisSessionRepository sessionRepository;
+
+    SafeRedisSessionMapper(RedisSessionRepository sessionRepository) {
+      this.sessionRepository = sessionRepository;
+    }
+
+    @Override
+    public MapSession apply(String sessionId, Map<String, Object> map) {
+      try {
+        return this.delegate.apply(sessionId, map);
+      } catch (IllegalStateException ex) {
+        this.sessionRepository.deleteById(sessionId);
+        return null;
+      }
+    }
+  }
+
+  @Bean
+  public CookieSerializer cookieSerializer() {
+    DefaultCookieSerializer serializer = new DefaultCookieSerializer();
+
+    serializer.setCookieName("KIND_SESSION");
+
+    serializer.setUseHttpOnlyCookie(true);
+    serializer.setUseSecureCookie(false);
+    serializer.setCookiePath("/");
+    serializer.setCookieMaxAge(604800);
+
+    return serializer;
+  }
+}

--- a/src/main/java/com/kindtalk/server/config/SessionConfig.java
+++ b/src/main/java/com/kindtalk/server/config/SessionConfig.java
@@ -53,7 +53,7 @@ public class SessionConfig {
     serializer.setCookieName("KIND_SESSION");
 
     serializer.setUseHttpOnlyCookie(true);
-    serializer.setUseSecureCookie(false);
+    serializer.setUseSecureCookie(true);
     serializer.setCookiePath("/");
     serializer.setCookieMaxAge(604800);
 

--- a/src/main/java/com/kindtalk/server/member/domain/Member.java
+++ b/src/main/java/com/kindtalk/server/member/domain/Member.java
@@ -7,10 +7,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-public class Member {
+public class Member implements Serializable {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/kindtalk/server/member/domain/Member.java
+++ b/src/main/java/com/kindtalk/server/member/domain/Member.java
@@ -7,12 +7,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.io.Serializable;
-
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-public class Member implements Serializable {
+public class Member {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/kindtalk/server/member/service/MemberService.java
+++ b/src/main/java/com/kindtalk/server/member/service/MemberService.java
@@ -52,13 +52,13 @@ public class MemberService {
 
   @Transactional(readOnly = true)
   public MemberResponse memberDetail(MyUserDetails auth) {
-    Member member = findById(auth.getMember().getId());
+    Member member = findById(auth.getMemberId());
     return MemberResponse.of(member);
   }
 
   @Transactional
   public MemberResponse memberUpdate(MyUserDetails auth, MemberUpdateRequest update) {
-    Member member = findById(auth.getMember().getId());
+    Member member = findById(auth.getMemberId());
     member.updateInfo(update.userName(), update.nickName());
     return MemberResponse.of(member);
   }

--- a/src/main/java/com/kindtalk/server/security/dto/LoginResponse.java
+++ b/src/main/java/com/kindtalk/server/security/dto/LoginResponse.java
@@ -1,8 +1,6 @@
 package com.kindtalk.server.security.dto;
 
-import com.kindtalk.server.member.role.Role;
-
 public record LoginResponse(
   String email,
-  Role role) {
+  String role) {
 }

--- a/src/main/java/com/kindtalk/server/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/kindtalk/server/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.kindtalk.server.security.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+  @Override
+  public void commence(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AuthenticationException authException) throws IOException {
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType("application/json;charset=UTF-8");
+    response.getWriter().write("{\"message\": \"로그인이 필요합니다.\"}");
+  }
+}

--- a/src/main/java/com/kindtalk/server/security/handler/CustomLoginSuccessHandler.java
+++ b/src/main/java/com/kindtalk/server/security/handler/CustomLoginSuccessHandler.java
@@ -1,7 +1,6 @@
 package com.kindtalk.server.security.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.kindtalk.server.member.domain.Member;
 import com.kindtalk.server.security.dto.LoginResponse;
 import com.kindtalk.server.security.principal.MyUserDetails;
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,10 +26,9 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
     response.setContentType("application/json;charset=UTF-8");
     response.setStatus(HttpStatus.OK.value());
 
-    MyUserDetails myUserDetails = (MyUserDetails) authentication.getPrincipal();
-    Member member = myUserDetails.getMember();
+    MyUserDetails auth = (MyUserDetails) authentication.getPrincipal();
 
-    LoginResponse data = new LoginResponse(member.getEmail(), member.getRole());
+    LoginResponse data = new LoginResponse(auth.getUsername(), auth.getRole());
     response.getWriter().write(objectMapper.writeValueAsString(data));
   }
 }

--- a/src/main/java/com/kindtalk/server/security/principal/MyUserDetails.java
+++ b/src/main/java/com/kindtalk/server/security/principal/MyUserDetails.java
@@ -3,6 +3,7 @@ package com.kindtalk.server.security.principal;
 import com.kindtalk.server.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.CredentialsContainer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -12,7 +13,7 @@ import java.util.Collection;
 import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MyUserDetails implements UserDetails, Serializable {
+public class MyUserDetails implements UserDetails, Serializable, CredentialsContainer {
 
   private static final long serialVersionUID = 1L;
 
@@ -26,6 +27,11 @@ public class MyUserDetails implements UserDetails, Serializable {
     this.email = member.getEmail();
     this.password = member.getPassword();
     this.role = member.getRole().name();
+  }
+
+  @Override
+  public void eraseCredentials() {
+    this.password = null;
   }
 
   @Override

--- a/src/main/java/com/kindtalk/server/security/principal/MyUserDetails.java
+++ b/src/main/java/com/kindtalk/server/security/principal/MyUserDetails.java
@@ -14,6 +14,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MyUserDetails implements UserDetails, Serializable {
 
+  private static final long serialVersionUID = 1L;
+
   private Long memberId;
   private String email;
   private String password;

--- a/src/main/java/com/kindtalk/server/security/principal/MyUserDetails.java
+++ b/src/main/java/com/kindtalk/server/security/principal/MyUserDetails.java
@@ -6,11 +6,12 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 
 @RequiredArgsConstructor
-public class MyUserDetails implements UserDetails {
+public class MyUserDetails implements UserDetails, Serializable {
 
   private final Member member;
 

--- a/src/main/java/com/kindtalk/server/security/principal/MyUserDetails.java
+++ b/src/main/java/com/kindtalk/server/security/principal/MyUserDetails.java
@@ -1,7 +1,8 @@
 package com.kindtalk.server.security.principal;
 
 import com.kindtalk.server.member.domain.Member;
-import lombok.RequiredArgsConstructor;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -10,32 +11,42 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 
-@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MyUserDetails implements UserDetails, Serializable {
 
-  private final Member member;
+  private Long memberId;
+  private String email;
+  private String password;
+  private String role;
+
+  public MyUserDetails(Member member) {
+    this.memberId = member.getId();
+    this.email = member.getEmail();
+    this.password = member.getPassword();
+    this.role = member.getRole().name();
+  }
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    return List.of(new SimpleGrantedAuthority("ROLE_" + member.getRole()));
+    return List.of(new SimpleGrantedAuthority("ROLE_" + role));
   }
 
-  public Member getMember() {
-    return member;
+  public String getRole() {
+    return role;
   }
 
   public Long getMemberId() {
-    return member.getId();
+    return memberId;
   }
 
   @Override
   public String getUsername() {
-    return member.getEmail();
+    return email;
   }
 
   @Override
   public String getPassword() {
-    return member.getPassword();
+    return password;
   }
 
   @Override

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,8 +1,16 @@
 spring:
+  session:
+    store-type: redis
+    redis:
+      namespace: "kindtalk:session"
+
   data:
     mongodb:
       uri: mongodb://root:1234@localhost:27017/chat?authSource=admin
-      
+    redis:
+      host: localhost
+      port: 6379
+
   datasource:
     url: jdbc:mysql://localhost:3306/kindtalk
     username: root
@@ -15,14 +23,16 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        
-debug: true
+        highlight_sql: true
+
+debug: false
 
 logging:
   level:
     org.springframework.web.socket: DEBUG
     org.springframework.messaging: DEBUG
     org.springframework.stomp: DEBUG
+    org.hibernate.SQL: INFO
 
 school:
   api:


### PR DESCRIPTION
구현 내용

### Session
- myUserDetails을 직렬화하여 redis에 저장하도록 하였습니다. 
- 세션 큐키 이름은 KIND_SESSION, 만료 시간은 7일로 설정하였습니다.
- 로그인 시 기존에 존재하던 세션 쿠키가 존재할 경우 자동으로 삭제하도록 구현하였습니다. 

추후 세션 만료시 Redis 내부 데이터가 자동으로 삭제되도록 설정을 추가할 예정입니다. 

### Security
- CustomAuthenticationEntryPoint을 추가하여 인증되지 않은 사용자가 접근 시,  401 Unauthorized(JSON) 응답을 반환하도록 하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Redis-backed HTTP session persistence for improved scalability and reliability
  * Custom JSON-formatted 401 responses for authentication failures

* **Bug Fixes / Behavior Changes**
  * Safer handling of corrupted sessions to prevent errors and remove invalid sessions
  * Login response now returns role as a string

* **Chores**
  * Dev config updated with Redis connection and session settings; session cookie set to KIND_SESSION
<!-- end of auto-generated comment: release notes by coderabbit.ai -->